### PR TITLE
feat(geval): pipeline de relevancia G-Eval — pilot, runner de producción, run completo y análisis

### DIFF
--- a/.code_quality/ruff.toml
+++ b/.code_quality/ruff.toml
@@ -101,4 +101,8 @@ known-third-party = ["fastapi", "pydantic"]
 # The builder embeds notebook source as string literals, so the same exemptions
 # apply; random.Random is used for reproducibility (seed=42), not crypto.
 "scripts/build_pilot_notebook.py" = ["RUF001", "RUF002", "PLR2004"]
+# Statistical analysis report: legitimately uses Greek letters (ρ, α) in its
+# output strings and correlation-band thresholds (0.2, 0.4, ...) that are
+# domain constants, not magic numbers.
+"scripts/analyze_geval.py" = ["RUF001", "RUF002", "PLR2004"]
 "configs/prompts/select_pilot_sample.py" = ["PLR2004", "S311"]

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ outputs/figures/*.png
 outputs/figures/*.pdf
 outputs/figures/*.svg
 
+# Claude Code runtime lock (regenerated per session, not project state)
+.claude/scheduled_tasks.lock
+
 ### Editors
 
 # Jupyter NB Checkpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **G-Eval — Ejecución del run completo y análisis de resultados** - Ejecución de `scripts/run_geval.py` sobre el 100% del dataset y análisis interpretado de la línea base automática de relevancia:
+    - **Run completo ejecutado**: 900/900 pares evaluados con éxito (0 fallos), evaluador `gpt-4o`, 37m 21s wall time, 1.172.164 tokens (1.090.187 input / 81.977 output), costo real **$3.5453**
+    - **Resultado principal**: correlación de Spearman G-Eval vs. `human_score` = **0.7565** (`strong`, p ≈ 8.5e-168, n=900); Pearson r = 0.7106; Kendall τ = 0.5705
+    - **Artefactos del run**: `outputs/geval_results.json` (900 resultados par-a-par), `outputs/geval_summary_stats.md`, `outputs/logs/geval_execution.log`
+    - `scripts/analyze_geval.py` - Script de análisis reutilizable que lee `geval_results.json` + el dataset y produce un reporte interpretado y ordenado más figuras de soporte:
+        - **Métricas de concordancia**: Spearman ρ, Pearson r, Kendall τ, MAE (0.90), RMSE (1.14), sesgo medio Δ (−0.75), hit-rate dentro de ±0.5 (36%) y ±1.0 (63%)
+        - **Techo inter-anotador (human ceiling)**: implementación propia de la concordancia entre los 4 anotadores humanos como referencia para juzgar ρ — Spearman pairwise medio (0.466), Spearman leave-one-out (1 anotador vs. media de los otros 3 = 0.580), **Krippendorff α ordinal** (0.466) e **ICC(2,1)** (0.466). Hallazgo: G-Eval (0.756) **supera** el techo de un anotador individual por +0.176, porque las etiquetas humanas son ruidosas (α < 0.667) — un evaluador más potente no aportaría ganancia medible
+        - **Desglose por familia y por modelo individual**: n, media humana, media G-Eval, sesgo y MAE por grupo
+        - **Matriz de confusión por bandas** (scores redondeados 1-5) con acuerdo exacto de banda
+        - **Top-10 mayores desacuerdos** en ambas direcciones (sobre- y sub-estimación)
+        - Cuatro funciones de figura (`fig_scatter`, `fig_residuals`, `fig_delta_boxplot`, `fig_mean_by_family`, `fig_ceiling`) en modo headless (`matplotlib.use("Agg")`)
+        - **CLI**: `--results` (default `outputs/geval_results.json`), `--output-dir` (default `outputs/`)
+    - **Schema de `outputs/geval_analysis_report.md`**: reporte en 9 secciones — resumen ejecutivo, métricas de concordancia, techo inter-anotador, desglose por familia, desglose por modelo, matriz de confusión, mayores desacuerdos, figuras y guía de lectura
+    - **Figuras nuevas** en `outputs/figures/`: `05_geval_vs_human_scatter.png`, `06_residual_histogram.png`, `07_delta_by_family_boxplot.png`, `08_mean_score_by_family.png`, `09_ceiling_comparison.png`
+    - `.code_quality/ruff.toml` - `scripts/analyze_geval.py` añadido a `per-file-ignores` para `RUF001`/`RUF002`/`PLR2004` (letras griegas ρ/α en strings de salida y umbrales de correlación que son constantes de dominio, no magic numbers — mismo precedente que `build_pilot_notebook.py`)
+    - `.gitignore` - Ignora `.claude/scheduled_tasks.lock` (lock de runtime de Claude Code, regenerado por sesión)
+
 - **G-Eval Production Runner (HU-04)** - Script ejecutable sobre el 100% de los pares (900) para producir la línea base automática de relevancia, secuencial, con reintentos y checkpoint:
     - `scripts/run_geval.py` - Runner de producción (~570 LOC):
         - **Retries con backoff exponencial** vía `tenacity` (2s → 60s, 5 intentos) sobre errores transitorios de OpenAI: `RateLimitError`, `APITimeoutError`, `APIConnectionError`, `InternalServerError`. Errores fatales (`AuthenticationError`, `PermissionDeniedError`, `NotFoundError`) abortan el run en la primera entrada en vez de gastar 75 minutos en 900 fallos idénticos

--- a/outputs/geval_analysis_report.md
+++ b/outputs/geval_analysis_report.md
@@ -1,0 +1,145 @@
+# G-Eval Run — Analysis Report
+
+_Generated: 2026-05-17T23:49:40.887768+00:00_
+
+## 1. Executive summary
+
+G-Eval (gpt-4o) scored **900 of 900** conversation-response pairs (0 failed) for relevance against four human annotators.
+
+- **Rank agreement with humans**: Spearman ρ = **0.756** (_strong_, p = 8.54e-168).
+- **Human ceiling**: a single annotator predicts the 4-rater consensus at ρ = 0.580; G-Eval's ρ = 0.756 is +0.176 vs. that ceiling.
+- **Linear agreement**: Pearson r = 0.711; Kendall τ = 0.571.
+- **Error magnitude**: MAE = 0.90, RMSE = 1.14 points on the 1-5 scale.
+- **Systematic bias**: mean Δ = -0.75 — G-Eval **under-rates** responses relative to humans (G-Eval mean 2.41 vs. human 3.16).
+- **Tolerance hit-rate**: 36% of pairs within ±0.5, 63% within ±1.0 of the human score.
+
+## 2. Agreement metrics
+
+| Metric | Value | Reading |
+|---|---|---|
+| Pairs analysed (n) | 900 | successful evaluations |
+| Spearman ρ | 0.7565 | rank correlation (strong) |
+| Spearman p-value | 8.54e-168 | significance |
+| Pearson r | 0.7106 | linear correlation |
+| Kendall τ | 0.5705 | concordance |
+| MAE | 0.9008 | mean absolute error (1-5 pts) |
+| RMSE | 1.1434 | penalises large misses |
+| Mean bias (Δ) | -0.7495 | + = G-Eval scores high |
+| Within ±0.5 | 35.9% | tight agreement |
+| Within ±1.0 | 62.6% | loose agreement |
+
+## 3. Human ceiling — inter-annotator agreement
+
+Spearman ρ can only be judged against how well the humans agree **with each other**. A metric cannot be expected to beat the noise floor of the labels it is graded on.
+
+| Reference | ρ / coefficient | Meaning |
+|---|---|---|
+| Two single humans (pairwise ρ) | 0.4660 | one annotator vs. another |
+| **Human ceiling (leave-one-out ρ)** | **0.5803** | one annotator vs. the mean of the other 3 |
+| **G-Eval vs. consensus** | **0.7565** | one G-Eval pass vs. the 4-human mean |
+| Krippendorff α (ordinal) | 0.4655 | standard reliability coefficient |
+| ICC(2,1) single rater | 0.4661 | absolute-agreement reliability of one rating |
+
+**Gap to ceiling: +0.1762.** G-Eval **exceeds the single-human ceiling** — it tracks the 4-rater consensus more closely than an individual annotator does. This is the expected outcome when the human labels are noisy: a *consistent* rater correlates with the average better than the noisy individuals correlate with each other. It does **not** mean G-Eval is 'better than humans' — the consensus is the target by construction — but it does mean a stronger evaluator model would buy essentially nothing: the gap left to ρ = 1.0 is mostly irreducible annotation noise, not model weakness.
+
+## 4. Breakdown by model family
+
+Families ordered by human-rated relevance (best first). `bias` is the mean G-Eval − human gap within the family.
+
+| Family | n | Human mean | G-Eval mean | Bias | MAE |
+|---|---|---|---|---|---|
+| ground-truth | 100 | 4.38 | 3.74 | -0.64 | 0.84 |
+| GPT2 | 300 | 3.60 | 2.69 | -0.91 | 1.06 |
+| VHRED | 105 | 2.83 | 2.02 | -0.81 | 0.96 |
+| HRED | 95 | 2.79 | 2.24 | -0.55 | 0.74 |
+| S2S | 200 | 2.77 | 2.10 | -0.66 | 0.81 |
+| negative-sample | 100 | 2.08 | 1.41 | -0.67 | 0.75 |
+
+## 5. Breakdown by individual model
+
+| Model | n | Human mean | G-Eval mean | Bias | MAE |
+|---|---|---|---|---|---|
+| ground-truth | 100 | 4.38 | 3.74 | -0.64 | 0.84 |
+| GPT2_medium greedy_temp1.0_k0_p0.0 | 33 | 4.09 | 3.11 | -0.98 | 1.14 |
+| GPT2_small top_temp1.0_k0_p0.5 | 37 | 3.91 | 3.01 | -0.91 | 1.07 |
+| GPT2_medium top_temp1.0_k0_p0.5 | 46 | 3.79 | 3.00 | -0.78 | 0.97 |
+| GPT2_small greedy_temp1.0_k0_p0.0 | 44 | 3.72 | 2.69 | -1.03 | 1.17 |
+| GPT2_small top_temp1.0_k0_p0.9 | 52 | 3.38 | 2.49 | -0.89 | 1.07 |
+| GPT2_medium sample_temp1.0_k0_p0.0 | 41 | 3.27 | 2.28 | -0.99 | 1.01 |
+| HRED_attn top_temp1.0_k0_p0.5 | 32 | 3.26 | 2.65 | -0.61 | 0.82 |
+| GPT2_small sample_temp1.0_k0_p0.0 | 47 | 3.26 | 2.41 | -0.84 | 1.02 |
+| VHRED_attn greedy_temp1.0_k0_p0.0 | 37 | 3.07 | 2.27 | -0.79 | 1.02 |
+| VHRED_attn top_temp1.0_k0_p0.5 | 26 | 2.96 | 2.15 | -0.82 | 0.95 |
+| S2S_attn greedy_temp1.0_k0_p0.0 | 38 | 2.96 | 2.33 | -0.64 | 0.78 |
+| S2S greedy_temp1.0_k0_p0.0 | 43 | 2.94 | 2.30 | -0.64 | 0.79 |
+| S2S_attn top_temp1.0_k0_p0.5 | 35 | 2.89 | 2.06 | -0.83 | 0.90 |
+| S2S top_temp1.0_k0_p0.5 | 32 | 2.87 | 2.26 | -0.60 | 0.82 |
+| HRED_attn greedy_temp1.0_k0_p0.0 | 34 | 2.82 | 2.23 | -0.58 | 0.73 |
+| S2S_attn sample_temp1.0_k0_p0.0 | 23 | 2.65 | 1.91 | -0.74 | 0.90 |
+| VHRED_attn sample_temp1.0_k0_p0.0 | 42 | 2.53 | 1.71 | -0.82 | 0.92 |
+| HRED_attn sample_temp1.0_k0_p0.0 | 29 | 2.23 | 1.79 | -0.44 | 0.66 |
+| S2S sample_temp1.0_k0_p0.0 | 29 | 2.09 | 1.56 | -0.52 | 0.68 |
+| negative-sample | 100 | 2.08 | 1.41 | -0.67 | 0.75 |
+
+## 6. Score-band confusion matrix
+
+Both scores rounded to the nearest integer (1-5). Exact-band agreement: **35.6%**. Rows = human, columns = G-Eval.
+
+| Human ↓ / G-Eval → | 1 | 2 | 3 | 4 | 5 |
+|---|---|---|---|---|---|
+| **5** | 0 | 23 | 20 | 51 | 22 |
+| **4** | 5 | 140 | 67 | 75 | 18 |
+| **3** | 17 | 104 | 31 | 11 | 0 |
+| **2** | 90 | 142 | 8 | 5 | 0 |
+| **1** | 50 | 19 | 2 | 0 | 0 |
+
+## 7. Largest disagreements
+
+### G-Eval over-rated (top 10 positive Δ)
+
+| conversation_id | model | human | G-Eval | Δ |
+|---|---|---|---|---|
+| conv_43_VHRED_attn greedy_temp1.0_k0_p0.0 | VHRED | 1.00 | 3.23 | +2.23 |
+| conv_18_GPT2_small top_temp1.0_k0_p0.9 | GPT2 | 1.00 | 2.85 | +1.85 |
+| conv_5_S2S top_temp1.0_k0_p0.5 | S2S | 2.00 | 3.77 | +1.77 |
+| conv_98_GPT2_medium greedy_temp1.0_k0_p0.0 | GPT2 | 2.75 | 4.28 | +1.53 |
+| conv_66_GPT2_small top_temp1.0_k0_p0.5 | GPT2 | 2.50 | 4.01 | +1.51 |
+| conv_45_ground-truth | ground-truth | 3.00 | 4.35 | +1.35 |
+| conv_55_VHRED_attn greedy_temp1.0_k0_p0.0 | VHRED | 1.00 | 2.35 | +1.35 |
+| conv_60_VHRED_attn top_temp1.0_k0_p0.5 | VHRED | 2.25 | 3.51 | +1.26 |
+| conv_89_ground-truth | ground-truth | 2.50 | 3.72 | +1.22 |
+| conv_41_ground-truth | ground-truth | 3.75 | 4.89 | +1.14 |
+
+### G-Eval under-rated (top 10 negative Δ)
+
+| conversation_id | model | human | G-Eval | Δ |
+|---|---|---|---|---|
+| conv_75_GPT2_small greedy_temp1.0_k0_p0.0 | GPT2 | 4.75 | 1.65 | -3.10 |
+| conv_9_GPT2_small top_temp1.0_k0_p0.9 | GPT2 | 5.00 | 1.99 | -3.01 |
+| conv_75_VHRED_attn greedy_temp1.0_k0_p0.0 | VHRED | 4.75 | 1.74 | -3.01 |
+| conv_37_GPT2_medium greedy_temp1.0_k0_p0.0 | GPT2 | 4.75 | 1.78 | -2.97 |
+| conv_62_GPT2_medium greedy_temp1.0_k0_p0.0 | GPT2 | 4.50 | 1.54 | -2.96 |
+| conv_30_GPT2_small top_temp1.0_k0_p0.9 | GPT2 | 4.75 | 1.86 | -2.89 |
+| conv_12_GPT2_small greedy_temp1.0_k0_p0.0 | GPT2 | 5.00 | 2.11 | -2.89 |
+| conv_37_GPT2_small greedy_temp1.0_k0_p0.0 | GPT2 | 4.50 | 1.71 | -2.79 |
+| conv_67_ground-truth | ground-truth | 4.75 | 1.96 | -2.79 |
+| conv_36_HRED_attn top_temp1.0_k0_p0.5 | HRED | 4.75 | 1.97 | -2.78 |
+
+## 8. Figures
+
+![G-Eval vs human](outputs/figures/05_geval_vs_human_scatter.png)
+
+![Residual histogram](outputs/figures/06_residual_histogram.png)
+
+![Residuals by family](outputs/figures/07_delta_by_family_boxplot.png)
+
+![Mean score by family](outputs/figures/08_mean_score_by_family.png)
+
+![G-Eval vs human ceiling](outputs/figures/09_ceiling_comparison.png)
+
+## 9. How to read this
+
+- The ρ of 0.76 should be read against the 0.58 human ceiling, not against 1.0 — no metric can out-agree the label noise it is graded on.
+- A Spearman ρ of 0.76 means G-Eval reproduces the human **ranking** of responses strongly — useful for picking the better of two responses even when absolute points differ.
+- The -0.75 bias is a *calibration* offset: it can be subtracted out before comparing against the 1-5 human scale.
+- Families where `bias` and `MAE` are largest are where the metric is least trustworthy and most worth a prompt revision.

--- a/scripts/analyze_geval.py
+++ b/scripts/analyze_geval.py
@@ -1,0 +1,609 @@
+"""Analyse a completed G-Eval run and produce an interpreted report.
+
+Reads the per-pair results written by ``run_geval.py`` plus the source
+dataset, then computes agreement metrics against the human relevance
+scores, breaks them down by model family and individual model, and writes
+an ordered markdown report with four supporting figures.
+
+Usage:
+    uv run python scripts/analyze_geval.py
+    uv run python scripts/analyze_geval.py --results outputs/geval_results.json
+
+Outputs (under ``outputs/``):
+    - geval_analysis_report.md          interpreted, ordered analysis
+    - figures/05_geval_vs_human_scatter.png
+    - figures/06_residual_histogram.png
+    - figures/07_delta_by_family_boxplot.png
+    - figures/08_mean_score_by_family.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless: write PNGs without a display server
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import kendalltau, pearsonr, spearmanr
+
+PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+DATA_PATH: Final[Path] = PROJECT_ROOT / "data" / "processed" / "deepeval_test_cases.json"
+DEFAULT_RESULTS: Final[Path] = PROJECT_ROOT / "outputs" / "geval_results.json"
+DEFAULT_OUTPUT_DIR: Final[Path] = PROJECT_ROOT / "outputs"
+
+# Agreement tolerances on the shared 1-5 scale.
+TOL_TIGHT: Final[float] = 0.5
+TOL_LOOSE: Final[float] = 1.0
+
+# Number of largest-error pairs to surface in the report.
+TOP_N_ERRORS: Final[int] = 10
+
+
+# ─── Correlation interpretation ──────────────────────────────────────────
+def interpret_rho(rho: float) -> str:
+    """Plain-language band for an absolute correlation coefficient."""
+    a = abs(rho)
+    if a < 0.20:
+        return "negligible"
+    if a < 0.40:
+        return "weak"
+    if a < 0.60:
+        return "moderate"
+    if a < 0.80:
+        return "strong"
+    return "very strong"
+
+
+def model_family(model_name: str) -> str:
+    """Collapse a dataset model name onto a coarse family label."""
+    if model_name in ("ground-truth", "negative-sample"):
+        return model_name
+    for family in ("GPT2", "VHRED", "HRED", "S2S"):
+        if model_name.startswith(family):
+            return family
+    return "other"
+
+
+# ─── Loading ─────────────────────────────────────────────────────────────
+def load_json(path: Path) -> Any:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _rel(path: Path) -> Path:
+    """Path relative to the project root, for portable markdown links."""
+    return path.relative_to(PROJECT_ROOT)
+
+
+def join_results(results: list[dict], dataset: list[dict]) -> list[dict]:
+    """Attach the dataset ``model`` and family to each successful result."""
+    id_to_model = {e["metadata"]["conversation_id"]: e["metadata"]["model"] for e in dataset}
+    joined = []
+    for r in results:
+        if r.get("geval_score") is None:
+            continue
+        model = id_to_model.get(r["conversation_id"], "unknown")
+        joined.append(
+            {
+                "conversation_id": r["conversation_id"],
+                "geval": float(r["geval_score"]),
+                "human": float(r["human_score"]),
+                "delta": float(r["geval_score"]) - float(r["human_score"]),
+                "model": model,
+                "family": model_family(model),
+                "reason": r.get("reason", ""),
+            }
+        )
+    return joined
+
+
+# ─── Metrics ─────────────────────────────────────────────────────────────
+def agreement_metrics(rows: list[dict]) -> dict[str, float]:
+    """Correlation + error metrics for G-Eval vs human scores."""
+    geval = np.array([r["geval"] for r in rows])
+    human = np.array([r["human"] for r in rows])
+    delta = geval - human
+
+    rho, rho_p = spearmanr(human, geval)
+    pear, pear_p = pearsonr(human, geval)
+    tau, tau_p = kendalltau(human, geval)
+
+    return {
+        "n": len(rows),
+        "spearman_rho": float(rho),
+        "spearman_p": float(rho_p),
+        "pearson_r": float(pear),
+        "pearson_p": float(pear_p),
+        "kendall_tau": float(tau),
+        "kendall_p": float(tau_p),
+        "mae": float(np.mean(np.abs(delta))),
+        "rmse": float(np.sqrt(np.mean(delta**2))),
+        "bias": float(np.mean(delta)),
+        "within_tight": float(np.mean(np.abs(delta) <= TOL_TIGHT)),
+        "within_loose": float(np.mean(np.abs(delta) <= TOL_LOOSE)),
+        "geval_mean": float(np.mean(geval)),
+        "human_mean": float(np.mean(human)),
+    }
+
+
+def per_group(rows: list[dict], key: str) -> list[dict]:
+    """Per-group (family or model) mean scores and bias, sorted by human mean."""
+    groups: dict[str, list[dict]] = {}
+    for r in rows:
+        groups.setdefault(r[key], []).append(r)
+    out = []
+    for name, grp in groups.items():
+        g = np.array([x["geval"] for x in grp])
+        h = np.array([x["human"] for x in grp])
+        out.append(
+            {
+                "name": name,
+                "n": len(grp),
+                "human_mean": float(np.mean(h)),
+                "geval_mean": float(np.mean(g)),
+                "bias": float(np.mean(g - h)),
+                "mae": float(np.mean(np.abs(g - h))),
+            }
+        )
+    return sorted(out, key=lambda d: d["human_mean"], reverse=True)
+
+
+def score_band_crosstab(rows: list[dict]) -> tuple[np.ndarray, float]:
+    """5x5 count matrix of rounded human vs G-Eval scores, plus exact-band agreement."""
+    matrix = np.zeros((5, 5), dtype=int)
+    hits = 0
+    for r in rows:
+        h = min(5, max(1, round(r["human"])))
+        g = min(5, max(1, round(r["geval"])))
+        matrix[5 - h, g - 1] += 1  # row 0 = human 5 (top), col 0 = geval 1
+        if h == g:
+            hits += 1
+    return matrix, hits / len(rows)
+
+
+# ─── Inter-annotator agreement (human ceiling) ───────────────────────────
+def _rating_matrix(dataset: list[dict]) -> np.ndarray:
+    """(n_units, 4) integer matrix of raw human relevance votes."""
+    rows = [
+        e["metadata"]["raw_relevance_scores"]
+        for e in dataset
+        if e["metadata"].get("raw_relevance_scores")
+    ]
+    return np.array(rows, dtype=int)
+
+
+def krippendorff_alpha_ordinal(ratings: np.ndarray) -> float:
+    """Krippendorff's alpha with the ordinal difference metric.
+
+    ``ratings`` is a (units x coders) matrix with no missing values. The
+    ordinal metric weights disagreements by the marginal mass between the
+    two categories, so a 1-vs-5 split costs far more than a 4-vs-5 split.
+    """
+    values = np.arange(1, 6)  # rating scale 1..5
+    idx = {int(v): i for i, v in enumerate(values)}
+    v_n = len(values)
+    n_units, m = ratings.shape
+
+    coincidence = np.zeros((v_n, v_n))
+    for unit in ratings:
+        counts = np.zeros(v_n)
+        for r in unit:
+            counts[idx[int(r)]] += 1
+        for c in range(v_n):
+            for k in range(v_n):
+                pairs = counts[c] * (counts[c] - 1) if c == k else counts[c] * counts[k]
+                coincidence[c, k] += pairs / (m - 1)
+
+    n_c = coincidence.sum(axis=1)
+    n = n_c.sum()
+
+    def delta2(c: int, k: int) -> float:
+        lo, hi = (c, k) if c <= k else (k, c)
+        gap = n_c[lo : hi + 1].sum() - (n_c[lo] + n_c[hi]) / 2.0
+        return float(gap * gap)
+
+    d_obs = sum(coincidence[c, k] * delta2(c, k) for c in range(v_n) for k in range(v_n)) / n
+    d_exp = sum(n_c[c] * n_c[k] * delta2(c, k) for c in range(v_n) for k in range(v_n)) / (
+        n * (n - 1)
+    )
+    return float(1 - d_obs / d_exp) if d_exp else 1.0
+
+
+def icc_2_1(ratings: np.ndarray) -> float:
+    """ICC(2,1): two-way random-effects, single-rater, absolute agreement.
+
+    Answers "how reliable is one annotator's raw score" on the 1-5 scale —
+    a stricter, value-level companion to the rank-based Spearman ceiling.
+    """
+    n, k = ratings.shape
+    grand = ratings.mean()
+    row_means = ratings.mean(axis=1)
+    col_means = ratings.mean(axis=0)
+
+    ss_rows = k * np.sum((row_means - grand) ** 2)
+    ss_cols = n * np.sum((col_means - grand) ** 2)
+    ss_total = np.sum((ratings - grand) ** 2)
+    ss_err = ss_total - ss_rows - ss_cols
+
+    ms_rows = ss_rows / (n - 1)
+    ms_cols = ss_cols / (k - 1)
+    ms_err = ss_err / ((n - 1) * (k - 1))
+
+    denom = ms_rows + (k - 1) * ms_err + k * (ms_cols - ms_err) / n
+    return float((ms_rows - ms_err) / denom) if denom else 0.0
+
+
+def human_ceiling(dataset: list[dict]) -> dict[str, float]:
+    """Inter-annotator agreement metrics — the ceiling G-Eval is judged against.
+
+    - pairwise: mean Spearman over the 6 annotator-column pairs (two single
+      humans agreeing with each other).
+    - leave_one_out: mean Spearman of each annotator column vs. the mean of
+      the other 3 — directly comparable to G-Eval, which is also one rater
+      predicting the human consensus.
+    """
+    ratings = _rating_matrix(dataset)
+    n_units, k = ratings.shape
+
+    pairwise = [
+        spearmanr(ratings[:, i], ratings[:, j]).statistic for i in range(k) for j in range(i + 1, k)
+    ]
+    loo = []
+    for j in range(k):
+        others = np.delete(ratings, j, axis=1).mean(axis=1)
+        loo.append(spearmanr(ratings[:, j], others).statistic)
+
+    return {
+        "n_units": n_units,
+        "n_annotators": k,
+        "pairwise_spearman": float(np.mean(pairwise)),
+        "loo_spearman": float(np.mean(loo)),
+        "krippendorff_alpha": krippendorff_alpha_ordinal(ratings),
+        "icc_2_1": icc_2_1(ratings.astype(float)),
+    }
+
+
+def ceiling_verdict(geval_rho: float, loo: float) -> str:
+    """Plain-language verdict comparing G-Eval to the human ceiling."""
+    if geval_rho > loo + 0.03:
+        return (
+            "G-Eval **exceeds the single-human ceiling** — it tracks the 4-rater "
+            "consensus more closely than an individual annotator does. This is the "
+            "expected outcome when the human labels are noisy: a *consistent* rater "
+            "correlates with the average better than the noisy individuals correlate "
+            "with each other. It does **not** mean G-Eval is 'better than humans' — "
+            "the consensus is the target by construction — but it does mean a "
+            "stronger evaluator model would buy essentially nothing: the gap left to "
+            "ρ = 1.0 is mostly irreducible annotation noise, not model weakness."
+        )
+    if geval_rho >= loo - 0.02:
+        return (
+            "G-Eval **matches the human ceiling** — a single G-Eval pass agrees "
+            "with the consensus about as well as a single human annotator does. "
+            "A stronger evaluator model would yield little to no measurable gain."
+        )
+    if geval_rho >= loo - 0.10:
+        return (
+            "G-Eval sits **just below the human ceiling** — close enough that the "
+            "remaining gap is within annotation noise; switching evaluator models "
+            "is unlikely to be worth the cost."
+        )
+    return (
+        "G-Eval sits **measurably below the human ceiling** — there is genuine "
+        "headroom, so a stronger evaluator model or a revised prompt could help."
+    )
+
+
+# ─── Figures ─────────────────────────────────────────────────────────────
+def fig_scatter(rows: list[dict], path: Path) -> None:
+    geval = np.array([r["geval"] for r in rows])
+    human = np.array([r["human"] for r in rows])
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.scatter(human, geval, alpha=0.35, s=20, edgecolor="none")
+    ax.plot([1, 5], [1, 5], "r--", lw=1, label="perfect agreement")
+    coef = np.polyfit(human, geval, 1)
+    xs = np.array([1, 5])
+    ax.plot(xs, coef[0] * xs + coef[1], "b-", lw=1.5, label="best fit")
+    ax.set_xlabel("Human relevance score (1-5)")
+    ax.set_ylabel("G-Eval relevance score (1-5)")
+    ax.set_title("G-Eval vs. human relevance")
+    ax.set_xlim(0.8, 5.2)
+    ax.set_ylim(0.8, 5.2)
+    ax.legend()
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+    plt.close(fig)
+
+
+def fig_residuals(rows: list[dict], path: Path) -> None:
+    delta = np.array([r["delta"] for r in rows])
+    fig, ax = plt.subplots(figsize=(7, 4.5))
+    ax.hist(delta, bins=40, color="#4477aa", edgecolor="white")
+    ax.axvline(0, color="red", ls="--", lw=1)
+    ax.axvline(
+        float(np.mean(delta)), color="black", lw=1.5, label=f"mean bias {np.mean(delta):+.2f}"
+    )
+    ax.set_xlabel("Δ = G-Eval − human")
+    ax.set_ylabel("Count")
+    ax.set_title("Residual distribution")
+    ax.legend()
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+    plt.close(fig)
+
+
+def fig_delta_boxplot(rows: list[dict], path: Path) -> None:
+    fams = sorted({r["family"] for r in rows})
+    data = [[r["delta"] for r in rows if r["family"] == f] for f in fams]
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    ax.boxplot(data, tick_labels=fams, showmeans=True)
+    ax.axhline(0, color="red", ls="--", lw=1)
+    ax.set_ylabel("Δ = G-Eval − human")
+    ax.set_title("Residuals by model family")
+    ax.grid(alpha=0.3, axis="y")
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+    plt.close(fig)
+
+
+def fig_mean_by_family(family_rows: list[dict], path: Path) -> None:
+    names = [g["name"] for g in family_rows]
+    human = [g["human_mean"] for g in family_rows]
+    geval = [g["geval_mean"] for g in family_rows]
+    x = np.arange(len(names))
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    ax.bar(x - 0.2, human, 0.4, label="human", color="#ee6677")
+    ax.bar(x + 0.2, geval, 0.4, label="G-Eval", color="#4477aa")
+    ax.set_xticks(x)
+    ax.set_xticklabels(names, rotation=20, ha="right")
+    ax.set_ylabel("Mean relevance score (1-5)")
+    ax.set_title("Mean score by model family: human vs. G-Eval")
+    ax.legend()
+    ax.grid(alpha=0.3, axis="y")
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+    plt.close(fig)
+
+
+def fig_ceiling(geval_rho: float, ceiling: dict[str, float], path: Path) -> None:
+    labels = [
+        "Two single humans\n(pairwise)",
+        "Human ceiling\n(1 rater vs consensus)",
+        "G-Eval\n(vs consensus)",
+    ]
+    vals = [ceiling["pairwise_spearman"], ceiling["loo_spearman"], geval_rho]
+    colors = ["#bbbbbb", "#ee6677", "#4477aa"]
+    fig, ax = plt.subplots(figsize=(7, 4))
+    bars = ax.barh(labels, vals, color=colors)
+    ax.axvline(ceiling["loo_spearman"], color="#ee6677", ls="--", lw=1)
+    for bar, v in zip(bars, vals, strict=True):
+        ax.text(v + 0.01, bar.get_y() + bar.get_height() / 2, f"{v:.3f}", va="center")
+    ax.set_xlim(0, 1)
+    ax.set_xlabel("Spearman ρ vs. consensus")
+    ax.set_title("G-Eval vs. the human agreement ceiling")
+    ax.grid(alpha=0.3, axis="x")
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+    plt.close(fig)
+
+
+# ─── Report ──────────────────────────────────────────────────────────────
+def build_report(  # noqa: PLR0913
+    rows: list[dict],
+    metrics: dict[str, float],
+    ceiling: dict[str, float],
+    by_family: list[dict],
+    by_model: list[dict],
+    crosstab: np.ndarray,
+    band_agreement: float,
+    n_total: int,
+    n_fail: int,
+    fig_dir: Path,
+) -> str:
+    rho = metrics["spearman_rho"]
+    bias = metrics["bias"]
+    direction = "over-rates" if bias > 0 else "under-rates"
+    loo = ceiling["loo_spearman"]
+    gap = rho - loo
+    over = sorted(rows, key=lambda r: r["delta"], reverse=True)[:TOP_N_ERRORS]
+    under = sorted(rows, key=lambda r: r["delta"])[:TOP_N_ERRORS]
+
+    L: list[str] = [
+        "# G-Eval Run — Analysis Report\n",
+        f"_Generated: {datetime.now(UTC).isoformat()}_\n",
+        "## 1. Executive summary\n",
+        f"G-Eval (gpt-4o) scored **{metrics['n']} of {n_total}** conversation-response "
+        f"pairs ({n_fail} failed) for relevance against four human annotators.\n",
+        f"- **Rank agreement with humans**: Spearman ρ = **{rho:.3f}** "
+        f"(_{interpret_rho(rho)}_, p = {metrics['spearman_p']:.2e}).",
+        f"- **Human ceiling**: a single annotator predicts the 4-rater consensus at "
+        f"ρ = {loo:.3f}; G-Eval's ρ = {rho:.3f} is {gap:+.3f} vs. that ceiling.",
+        f"- **Linear agreement**: Pearson r = {metrics['pearson_r']:.3f}; "
+        f"Kendall τ = {metrics['kendall_tau']:.3f}.",
+        f"- **Error magnitude**: MAE = {metrics['mae']:.2f}, RMSE = {metrics['rmse']:.2f} "
+        "points on the 1-5 scale.",
+        f"- **Systematic bias**: mean Δ = {bias:+.2f} — G-Eval **{direction}** responses "
+        f"relative to humans (G-Eval mean {metrics['geval_mean']:.2f} vs. human "
+        f"{metrics['human_mean']:.2f}).",
+        f"- **Tolerance hit-rate**: {metrics['within_tight']:.0%} of pairs within ±{TOL_TIGHT}, "
+        f"{metrics['within_loose']:.0%} within ±{TOL_LOOSE} of the human score.\n",
+        "## 2. Agreement metrics\n",
+        "| Metric | Value | Reading |",
+        "|---|---|---|",
+        f"| Pairs analysed (n) | {metrics['n']} | successful evaluations |",
+        f"| Spearman ρ | {rho:.4f} | rank correlation ({interpret_rho(rho)}) |",
+        f"| Spearman p-value | {metrics['spearman_p']:.2e} | significance |",
+        f"| Pearson r | {metrics['pearson_r']:.4f} | linear correlation |",
+        f"| Kendall τ | {metrics['kendall_tau']:.4f} | concordance |",
+        f"| MAE | {metrics['mae']:.4f} | mean absolute error (1-5 pts) |",
+        f"| RMSE | {metrics['rmse']:.4f} | penalises large misses |",
+        f"| Mean bias (Δ) | {bias:+.4f} | + = G-Eval scores high |",
+        f"| Within ±{TOL_TIGHT} | {metrics['within_tight']:.1%} | tight agreement |",
+        f"| Within ±{TOL_LOOSE} | {metrics['within_loose']:.1%} | loose agreement |\n",
+        "## 3. Human ceiling — inter-annotator agreement\n",
+        "Spearman ρ can only be judged against how well the humans agree **with each "
+        "other**. A metric cannot be expected to beat the noise floor of the labels "
+        "it is graded on.\n",
+        "| Reference | ρ / coefficient | Meaning |",
+        "|---|---|---|",
+        f"| Two single humans (pairwise ρ) | {ceiling['pairwise_spearman']:.4f} | "
+        "one annotator vs. another |",
+        f"| **Human ceiling (leave-one-out ρ)** | **{loo:.4f}** | one annotator vs. "
+        "the mean of the other 3 |",
+        f"| **G-Eval vs. consensus** | **{rho:.4f}** | one G-Eval pass vs. the 4-human mean |",
+        f"| Krippendorff α (ordinal) | {ceiling['krippendorff_alpha']:.4f} | standard "
+        "reliability coefficient |",
+        f"| ICC(2,1) single rater | {ceiling['icc_2_1']:.4f} | absolute-agreement "
+        "reliability of one rating |\n",
+        f"**Gap to ceiling: {gap:+.4f}.** {ceiling_verdict(rho, loo)}\n",
+        "## 4. Breakdown by model family\n",
+        "Families ordered by human-rated relevance (best first). `bias` is the mean "
+        "G-Eval − human gap within the family.\n",
+        "| Family | n | Human mean | G-Eval mean | Bias | MAE |",
+        "|---|---|---|---|---|---|",
+    ]
+    for g in by_family:
+        L.append(
+            f"| {g['name']} | {g['n']} | {g['human_mean']:.2f} | {g['geval_mean']:.2f} | "
+            f"{g['bias']:+.2f} | {g['mae']:.2f} |"
+        )
+
+    L += [
+        "\n## 5. Breakdown by individual model\n",
+        "| Model | n | Human mean | G-Eval mean | Bias | MAE |",
+        "|---|---|---|---|---|---|",
+    ]
+    for g in by_model:
+        L.append(
+            f"| {g['name']} | {g['n']} | {g['human_mean']:.2f} | {g['geval_mean']:.2f} | "
+            f"{g['bias']:+.2f} | {g['mae']:.2f} |"
+        )
+
+    L += [
+        "\n## 6. Score-band confusion matrix\n",
+        f"Both scores rounded to the nearest integer (1-5). Exact-band agreement: "
+        f"**{band_agreement:.1%}**. Rows = human, columns = G-Eval.\n",
+        "| Human ↓ / G-Eval → | 1 | 2 | 3 | 4 | 5 |",
+        "|---|---|---|---|---|---|",
+    ]
+    for i, h in enumerate(range(5, 0, -1)):
+        cells = " | ".join(str(int(crosstab[i, j])) for j in range(5))
+        L.append(f"| **{h}** | {cells} |")
+
+    L += [
+        "\n## 7. Largest disagreements\n",
+        f"### G-Eval over-rated (top {TOP_N_ERRORS} positive Δ)\n",
+        "| conversation_id | model | human | G-Eval | Δ |",
+        "|---|---|---|---|---|",
+    ]
+    for r in over:
+        L.append(
+            f"| {r['conversation_id']} | {r['family']} | {r['human']:.2f} | "
+            f"{r['geval']:.2f} | {r['delta']:+.2f} |"
+        )
+    L += [
+        f"\n### G-Eval under-rated (top {TOP_N_ERRORS} negative Δ)\n",
+        "| conversation_id | model | human | G-Eval | Δ |",
+        "|---|---|---|---|---|",
+    ]
+    for r in under:
+        L.append(
+            f"| {r['conversation_id']} | {r['family']} | {r['human']:.2f} | "
+            f"{r['geval']:.2f} | {r['delta']:+.2f} |"
+        )
+
+    L += [
+        "\n## 8. Figures\n",
+        f"![G-Eval vs human]({_rel(fig_dir)}/05_geval_vs_human_scatter.png)\n",
+        f"![Residual histogram]({_rel(fig_dir)}/06_residual_histogram.png)\n",
+        f"![Residuals by family]({_rel(fig_dir)}/07_delta_by_family_boxplot.png)\n",
+        f"![Mean score by family]({_rel(fig_dir)}/08_mean_score_by_family.png)\n",
+        f"![G-Eval vs human ceiling]({_rel(fig_dir)}/09_ceiling_comparison.png)\n",
+        "## 9. How to read this\n",
+        f"- The ρ of {rho:.2f} should be read against the {loo:.2f} human ceiling, "
+        "not against 1.0 — no metric can out-agree the label noise it is graded on.",
+        f"- A Spearman ρ of {rho:.2f} means G-Eval reproduces the human **ranking** "
+        f"of responses {interpret_rho(rho)}ly — useful for picking the better of two "
+        "responses even when absolute points differ.",
+        f"- The {bias:+.2f} bias is a *calibration* offset: it can be subtracted out "
+        "before comparing against the 1-5 human scale.",
+        "- Families where `bias` and `MAE` are largest are where the metric is least "
+        "trustworthy and most worth a prompt revision.",
+        "",
+    ]
+    return "\n".join(L)
+
+
+# ─── Orchestration ───────────────────────────────────────────────────────
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Analyse a completed G-Eval run.")
+    p.add_argument(
+        "--results", type=Path, default=DEFAULT_RESULTS, help="Path to geval_results.json."
+    )
+    p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR, help="Output directory.")
+    return p.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args()
+    results = load_json(args.results)
+    dataset = load_json(DATA_PATH)
+
+    n_total = len(results)
+    n_fail = sum(1 for r in results if r.get("geval_score") is None)
+    rows = join_results(results, dataset)
+    if not rows:
+        raise SystemExit("No successful results to analyse.")
+
+    metrics = agreement_metrics(rows)
+    ceiling = human_ceiling(dataset)
+    by_family = per_group(rows, "family")
+    by_model = per_group(rows, "model")
+    crosstab, band_agreement = score_band_crosstab(rows)
+
+    fig_dir = args.output_dir / "figures"
+    fig_dir.mkdir(parents=True, exist_ok=True)
+    fig_scatter(rows, fig_dir / "05_geval_vs_human_scatter.png")
+    fig_residuals(rows, fig_dir / "06_residual_histogram.png")
+    fig_delta_boxplot(rows, fig_dir / "07_delta_by_family_boxplot.png")
+    fig_mean_by_family(by_family, fig_dir / "08_mean_score_by_family.png")
+    fig_ceiling(metrics["spearman_rho"], ceiling, fig_dir / "09_ceiling_comparison.png")
+
+    report = build_report(
+        rows,
+        metrics,
+        ceiling,
+        by_family,
+        by_model,
+        crosstab,
+        band_agreement,
+        n_total,
+        n_fail,
+        fig_dir,
+    )
+    report_path = args.output_dir / "geval_analysis_report.md"
+    report_path.write_text(report, encoding="utf-8")
+    print(f"Analysis written to {report_path}")
+    print(f"Figures written to {fig_dir}")
+    print(
+        f"n={metrics['n']}  Spearman={metrics['spearman_rho']:.3f}  "
+        f"MAE={metrics['mae']:.2f}  bias={metrics['bias']:+.2f}"
+    )
+    print(
+        f"Human ceiling: leave-one-out ρ={ceiling['loo_spearman']:.3f}  "
+        f"pairwise ρ={ceiling['pairwise_spearman']:.3f}  "
+        f"Krippendorff α={ceiling['krippendorff_alpha']:.3f}  "
+        f"gap={metrics['spearman_rho'] - ceiling['loo_spearman']:+.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
✨ Context
El proyecto de tesis evalúa agentic voting; esta línea de trabajo (HU-03 y HU-04) construye la línea base automática de relevancia usando G-Eval (LLM-as-judge) sobre el dataset DailyDialog-Zhao, para contrastar el juicio de un modelo contra las anotaciones humanas de 4 evaluadores. Este PR consolida toda esa épica: desde el diseño del prompt hasta el run completo de 900 pares y su análisis interpretado.

🧠 Rationale behind the change
Evaluador gpt-4o: sucesor directo del GPT-4 usado en el paper original de G-Eval (Liu et al., EMNLP 2023); es el evaluador recomendado, no un downgrade.
Prompt anclado V3: el pilot mostró que la rúbrica con CoT + ejemplos anclados por score reduce la varianza frente a un prompt genérico — trade-off: prompt más largo (más tokens/costo) a cambio de scores más estables.
Runner secuencial con checkpoint: el run cuesta dinero real (~$3.5) y dura ~37 min; el checkpoint + escritura atómica cada 25 entradas garantiza que un Ctrl+C o crash nunca pierda lo evaluado. Secuencial (no paralelo) para no chocar con rate limits.
Techo inter-anotador en el análisis: una ρ de 0.756 no se puede juzgar contra 1.0 sino contra cuánto concuerdan los humanos entre sí — por eso el análisis añade Krippendorff α / ICC / leave-one-out como referencia.
Type of changes
 ✨ New Feature (changes that introduce new functionality)
 ⚗️ Experiments (A notebook with experimentation results)
 📝 Documentation
 ✅ Tests (Unit tests, integration tests, end-to-end tests)
 👷 🔧 CI or Configuration Files
🛠 What does this PR implement
1. Pilot del prompt de relevancia (HU-03)

configs/prompts/select_pilot_sample.py — sampler estratificado determinista (20 entradas, 5 estratos).
3 versiones iteradas del prompt (v1_generic, v2_dialogue_cot, v3_full_cot_anchored) + resultados del pilot; V3 seleccionado como geval_relevance_prompt.txt.
notebooks/01_eda.ipynb y notebooks/02_prompt_pilot.ipynb.
2. Fix del schema del dataset (speaker labels)

Roles user/assistant derivados del speaker label en vez de la paridad del índice de turno; corrige extracción del input cuando contexto y response_speaker no se alinean.
3. Runner de producción G-Eval (HU-04)

scripts/run_geval.py — secuencial, con retries (backoff exponencial vía tenacity), checkpoint con escritura atómica, resume automático, logging dual y conteo de tokens/costo determinista con tiktoken.
4. Ejecución del run completo + análisis (esta entrega)

Run completo: 900/900 pares evaluados, 0 fallos, gpt-4o, 37m 21s, $3.5453. Resultado: Spearman ρ = 0.7565 (strong, p ≈ 8.5e-168).
scripts/analyze_geval.py — análisis reutilizable: métricas de concordancia (Spearman/Pearson/Kendall, MAE 0.90, RMSE 1.14, sesgo −0.75), techo inter-anotador (pairwise ρ, leave-one-out ρ, Krippendorff α ordinal, ICC(2,1)), desglose por familia/modelo, matriz de confusión por bandas, top-10 desacuerdos y 5 figuras.
outputs/geval_analysis_report.md — reporte interpretado en 9 secciones. Hallazgo clave: G-Eval (0.756) supera el techo de un anotador individual (0.580); el modelo ya está al límite que permite el ruido de las etiquetas humanas.
5. Tests y configuración

tests/test_run_geval.py (41 tests, sin llamadas a API), más test_download_dataset.py / test_transform.py.
.code_quality/ruff.toml — analyze_geval.py exento de RUF001/RUF002/PLR2004 (letras griegas y umbrales estadísticos).
.gitignore — ignora .claude/scheduled_tasks.lock.
🙈 Missing
Solo se evaluó la dimensión Relevancia; la dimensión Appropriateness (presente en el dataset) queda pendiente.
Una sola pasada por par (sin temperature=0 ni repeticiones): no se midió la varianza run-to-run de G-Eval.
El sesgo de calibración de −0.75 está documentado y analizado, pero no corregido — el reescalado lineal 1 + 4·raw se mantiene tal cual.
CI no ejecuta el run completo de G-Eval (costo en API); solo corren los tests con mocks offline.
🧪 How should this be tested?

# Suite completa (sin llamadas a API)
uv run pytest --cov

# Hooks de calidad
uv run pre-commit run --all-files

# Smoke test del runner contra la API real (~$0.01)
uv run python scripts/run_geval.py --limit 2

# Regenerar el análisis y las figuras desde los resultados
uv run python scripts/analyze_geval.py
Resultado esperado del análisis: n=900  Spearman=0.756  MAE=0.90  bias=-0.75.