### PR TITLE
Agent panel design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Sistema de Votación — Diseño del panel de agentes juez** - Definición declarativa del cuerpo evaluador del sistema de votación. Sin llamadas a APIs ni ejecución, solo configs y diseño:
+    - **Tres archivos YAML de agentes** en `configs/agents/`, uno por proveedor, con la estructura exacta del Definition of Done (`name`, `model`, `provider`, `api_key_env`, `temperature`, `max_tokens`, `prompt_file`, `evaluation_dimension`, `score_range`, `independence`, `methodology_note`) y un bloque de comentarios `INDEPENDENCE GUARANTEE` al inicio:
+        - `agent_openai.yaml`: `judge_openai` con modelo `gpt-4o`
+        - `agent_google.yaml`: `judge_google` con modelo `gemini-2.5-flash`
+        - `agent_anthropic.yaml`: `judge_anthropic` con modelo `claude-haiku-4-5` (lanzamiento de octubre de 2025)
+    - **`temperature: 0.0` en los tres jueces**, no negociable: garantiza determinismo del juicio dado el mismo input y reproducibilidad entre corridas.
+    - **Prompt único V3 compartido por los tres agentes** (`configs/prompts/geval_relevance_prompt.txt`, sin modificar). Decisión metodológica explícita: se reemplaza el requisito de diversidad estilística de prompts por el de **control científico estricto**, de modo que las diferencias entre `judge_openai` y G-Eval queden atribuibles únicamente a la mecánica de scoring (form-filling con logprobs en DeepEval frente a prompting directo con parser), y las diferencias entre el panel agregado y G-Eval queden atribuibles a la mecánica de scoring más la agregación.
+    - **`gpt-4o` aparece tanto en G-Eval como en el panel** de forma deliberada, para aislar el efecto del método de evaluación del efecto del modelo.
+    - **Diversidad del panel** restringida a proveedor y modelo (tres proveedores independientes: OpenAI, Google, Anthropic).
+    - `docs/agent_panel_design.md` — Documento académico en español con once secciones (contexto, fundamentación metodológica, arquitectura con diagrama ASCII, descripción por agente, garantía de diversidad, mecanismo de independencia, mitigación de sesgos, relación con G-Eval, limitaciones conocidas, estimación de costos y referencias en formato APA con URL consultable). Sin emojis ni caracteres tipo IA, en línea con el estilo de `docs/voting_scheme_analysis.md`.
+    - **Estimación de costos del panel**: aproximadamente 7.61 USD para 900 pares (4.50 USD OpenAI, 0.89 USD Google, 2.22 USD Anthropic), llevando el total estimado de la tesis a entre 12 y 13 USD incluido el baseline G-Eval ya ejecutado.
+    - **Limitaciones declaradas explícitamente**: sesgo de longitud no mitigado por el prompt V3 (a vigilar en el pilot del panel), sacrificio consciente de la diversidad de estilo de prompt como precio del control científico, asimetría potencial de calidad por la presencia de `claude-haiku-4-5` (modelo eficiente) junto a dos modelos de mayor escala.
+
 - **Sistema de Votación — Análisis y selección del esquema de votación (HU-05)** - Documento de calidad académica que abre el bloque del sistema de votación agéntico y fija el operador de agregación del panel de jueces de IA:
     - `docs/voting_scheme_analysis.md` - Análisis en 6 secciones, en español, con el formato de `docs/dataset_selection.md`:
         - **Revisión de 5 esquemas** de agregación (mayoría/moda, media aritmética, mediana, votación ponderada y recuento de Borda), cada uno con descripción, ventajas, limitaciones y aplicabilidad a puntuaciones ordinales 1-5 emitidas por jueces de IA

--- a/configs/agents/agent_anthropic.yaml
+++ b/configs/agents/agent_anthropic.yaml
@@ -1,0 +1,28 @@
+---
+# INDEPENDENCE GUARANTEE:
+# This agent evaluates each conversation independently.
+# It has no access to scores from other agents.
+# It has no access to human annotation scores.
+# It has no access to G-Eval scores.
+# temperature=0.0 ensures deterministic outputs given the same input.
+
+name: "judge_anthropic"
+model: "claude-haiku-4-5"
+provider: "anthropic"
+api_key_env: "ANTHROPIC_API_KEY"
+temperature: 0.0
+max_tokens: 512
+prompt_file: "configs/prompts/geval_relevance_prompt.txt"
+evaluation_dimension: "relevance"
+score_range:
+  min: 1
+  max: 5
+independence: true
+methodology_note: >
+  claude-haiku-4-5 (released October 2025) is Anthropic's efficient model
+  and completes the three-provider diversity requirement. Extended thinking
+  is intentionally not used here, to keep evaluation conditions comparable
+  with the other two judges. The relevance prompt is the V3 prompt used
+  by G-Eval, shared across the panel as a deliberate scientific control so
+  that cross-judge differences are attributable to model and provider,
+  not to prompt variation.

--- a/configs/agents/agent_google.yaml
+++ b/configs/agents/agent_google.yaml
@@ -1,0 +1,27 @@
+---
+# INDEPENDENCE GUARANTEE:
+# This agent evaluates each conversation independently.
+# It has no access to scores from other agents.
+# It has no access to human annotation scores.
+# It has no access to G-Eval scores.
+# temperature=0.0 ensures deterministic outputs given the same input.
+
+name: "judge_google"
+model: "gemini-2.5-flash"
+provider: "google"
+api_key_env: "GOOGLE_API_KEY"
+temperature: 0.0
+max_tokens: 512
+prompt_file: "configs/prompts/geval_relevance_prompt.txt"
+evaluation_dimension: "relevance"
+score_range:
+  min: 1
+  max: 5
+independence: true
+methodology_note: >
+  gemini-2.5-flash is Google's flagship-comparable model and provides
+  provider diversity in the panel at significantly lower cost than gpt-4o.
+  The relevance prompt is the V3 prompt used by G-Eval, held constant
+  across the three judges so that cross-judge differences are attributable
+  to model and provider, not to prompt variation. This is the second
+  independent provider in the panel after OpenAI.

--- a/configs/agents/agent_openai.yaml
+++ b/configs/agents/agent_openai.yaml
@@ -1,0 +1,30 @@
+---
+# INDEPENDENCE GUARANTEE:
+# This agent evaluates each conversation independently.
+# It has no access to scores from other agents.
+# It has no access to human annotation scores.
+# It has no access to G-Eval scores.
+# temperature=0.0 ensures deterministic outputs given the same input.
+
+name: "judge_openai"
+model: "gpt-4o"
+provider: "openai"
+api_key_env: "OPENAI_API_KEY"
+temperature: 0.0
+max_tokens: 512
+prompt_file: "configs/prompts/geval_relevance_prompt.txt"
+evaluation_dimension: "relevance"
+score_range:
+  min: 1
+  max: 5
+independence: true
+methodology_note: >
+  gpt-4o is the same model used in the G-Eval baseline (Liu et al., 2023).
+  This agent also reuses the V3 relevance prompt unchanged. With model
+  and prompt held constant, judge_openai differs from G-Eval only in
+  scoring mechanics (direct prompting with score parsing rather than
+  DeepEval's GEval form-filling on logprobs) and in being one judge of
+  an aggregated panel rather than a single-judge system. Any difference
+  in Spearman correlation with human judgments between judge_openai and
+  the G-Eval baseline is therefore attributable to these two factors,
+  not to model or prompt variation.

--- a/docs/agent_panel_design.md
+++ b/docs/agent_panel_design.md
@@ -1,0 +1,163 @@
+# Agent Panel Design - HU-06
+## Diseño del Panel de Agentes Juez del Sistema de Votación Agéntico
+
+> Tesis de Maestría | Componente: Sistema de Votación Agéntico | Métrica objetivo: Relevance | Escala: 1 a 5 ordinal
+
+---
+
+## 1. Contexto de la tesis
+
+Este panel constituye el cuerpo evaluador del sistema de votación agéntico que se contrasta con G-Eval (Liu et al., 2023) sobre el dataset DailyDialog-Zhao. Se eligen tres agentes juez para satisfacer simultáneamente dos requisitos del Definition of Done: diversidad de proveedores (al menos dos proveedores distintos de modelos de lenguaje) y un número impar de votos que facilite la agregación por media y por mediana, esta última siempre definida sin reglas de desempate.
+
+---
+
+## 2. Fundamentación metodológica
+
+La decisión metodológica central es deliberada: el modelo `gpt-4o` aparece simultáneamente como evaluador único en el baseline G-Eval y como uno de los tres jueces del panel. La elección no es accidental, sino el mecanismo principal de control experimental.
+
+En esta tesis se sostiene constante el prompt de evaluación de relevancia, V3, en los tres jueces del panel. V3 es exactamente el mismo prompt utilizado por el baseline G-Eval. Con el prompt constante y con `gpt-4o` presente en ambos sistemas, el juez `judge_openai` del panel difiere del baseline G-Eval únicamente en dos factores: (i) la mecánica de extracción del score (G-Eval emplea `GEval` de DeepEval, que rellena un formulario sobre las probabilidades de los tokens; el juez del panel usa prompting directo y un parser explícito del score en la salida) y (ii) la participación en un panel agregado en lugar de un juicio individual. Por tanto, la comparación `judge_openai` frente a G-Eval queda como una prueba controlada del cambio de mecánica de scoring, y la comparación del panel agregado frente a G-Eval queda como una prueba del cambio combinado de mecánica de scoring y agregación. Cualquier diferencia en la correlación de Spearman contra el `human_score` se interpreta a la luz de estas dos contribuciones, sin que la variación de prompt sea una hipótesis alternativa que el director o el jurado puedan oponer.
+
+Esta decisión sustituye, de manera explícita, el requisito de diversidad estilística de prompts por el requisito de control científico de la comparación. La consecuencia en la mitigación de sesgos se documenta en la Sección 7 y la limitación derivada en la Sección 9.
+
+---
+
+## 3. Arquitectura del panel
+
+El siguiente diagrama representa la topología de evaluación. Cada juez recibe el mismo input y produce su puntuación de manera aislada; las tres puntuaciones se entregan al agregador definido en la historia de usuario anterior.
+
+```text
+  Conversation Input (turns + response)
+           |
+           v
+  +-----------------------------------------+
+  |              AGENT PANEL                |
+  |  +----------+ +----------+ +----------+ |
+  |  | Agent 1  | | Agent 2  | | Agent 3  | |
+  |  |  gpt-4o  | |  gemini  | |  claude  | |
+  |  | (OpenAI) | | 2.5-flash| | haiku-4-5| |
+  |  +----------+ +----------+ +----------+ |
+  |   Score 1      Score 2      Score 3     |
+  |        [evaluated independently]        |
+  +-----------------------------------------+
+           |
+           v
+     Aggregator (HU anterior: media + mediana de robustez)
+           |
+           v
+     Final Vote Score (1 a 5)
+```
+
+---
+
+## 4. Descripción de los agentes
+
+### 4.1 Agent 1: `judge_openai` (`gpt-4o`)
+
+Modelo `gpt-4o` del proveedor OpenAI, configurado en `configs/agents/agent_openai.yaml`. La selección obedece al control metodológico descrito en la Sección 2: al coincidir con el modelo del baseline G-Eval y al usar el mismo prompt V3, este juez aísla el efecto del cambio de mecánica de scoring respecto al baseline. El estilo de razonamiento del prompt es el del V3: cinco pasos de chain-of-thought, rúbrica anclada por nivel y tres ejemplos contextualizados. La temperatura se fija en 0.0 para garantizar reproducibilidad del juicio dado el mismo input; los logs y resultados podrán por tanto compararse de manera determinista entre corridas.
+
+### 4.2 Agent 2: `judge_google` (`gemini-2.5-flash`)
+
+Modelo `gemini-2.5-flash` del proveedor Google, configurado en `configs/agents/agent_google.yaml`. Aporta la segunda familia de proveedor al panel, requisito explícito del Definition of Done. La elección de la variante `flash` privilegia un coste sustancialmente menor que `gpt-4o` con calidad comparable para tareas de evaluación, lo cual hace posible mantener el presupuesto del experimento dentro del orden de magnitud del baseline. El prompt es V3, idéntico al usado por `judge_openai`. La temperatura se fija en 0.0 por la misma razón de determinismo. El modo de razonamiento extendido (thinking) se desactivará en el runner posterior para preservar la comparabilidad con los otros dos jueces.
+
+### 4.3 Agent 3: `judge_anthropic` (`claude-haiku-4-5`)
+
+Modelo `claude-haiku-4-5` del proveedor Anthropic, lanzado en octubre de 2025, configurado en `configs/agents/agent_anthropic.yaml`. Aporta la tercera familia de proveedor y completa la diversidad requerida. El prompt es V3. La temperatura se fija en 0.0. El razonamiento extendido (extended thinking) no se utiliza, por la misma razón de comparabilidad de condiciones de evaluación entre los tres jueces.
+
+---
+
+## 5. Garantía de diversidad
+
+La diversidad del panel se restringe a los ejes de proveedor y modelo, como consecuencia directa de la decisión metodológica de prompt único descrita en la Sección 2.
+
+| Dimensión | Agent 1 | Agent 2 | Agent 3 |
+|---|---|---|---|
+| Proveedor | OpenAI | Google | Anthropic |
+| Modelo | gpt-4o | gemini-2.5-flash | claude-haiku-4-5 |
+
+Nota explícita: el diseño no busca diversidad de estilo de prompt. Ese eje, que en otras propuestas de panel de jueces se utiliza como mecanismo adicional de mitigación de sesgo (Verga et al., 2024), se sacrifica de manera consciente para preservar el control científico de la comparación con G-Eval. El precio metodológico de esta decisión se asume y se documenta como limitación en la Sección 9.
+
+---
+
+## 6. Mecanismo de independencia
+
+Cada juez del panel cumple las siguientes condiciones de independencia, ya declaradas en el bloque de comentarios `INDEPENDENCE GUARANTEE` al inicio de cada YAML:
+
+- Recibe el mismo input de manera aislada, sin información lateral.
+- No tiene acceso a las puntuaciones de los otros jueces.
+- No tiene acceso a las puntuaciones de G-Eval.
+- No tiene acceso a las anotaciones humanas ni a derivados de estas.
+- Usa `temperature: 0.0`, lo que garantiza una salida determinista para el mismo input.
+
+El runner que se implementará en una HU posterior debe respetar este contrato mediante tres llamadas independientes a tres APIs distintas, sin compartir contexto entre llamadas.
+
+---
+
+## 7. Estrategia de mitigación de sesgos
+
+Con la decisión de prompt único, tres de los cuatro riesgos del diseño original quedan mitigados; el cuarto, el sesgo de longitud, se transfiere a la Sección 9 como limitación conocida.
+
+| Riesgo | Mecanismo de mitigación |
+|---|---|
+| Autopreferencia del modelo (un modelo puntúa mejor las respuestas que se parecen a su propia distribución) | Tres proveedores distintos en el panel. La autopreferencia, si existe, no se reforzaría por consenso. |
+| Compresión de la distribución hacia el centro (tendencia a puntuar 3) | Rúbrica anclada del V3, con un descriptor conductual por nivel (1 a 5) y tres ejemplos. Esto fuerza al juez a usar todo el rango y no refugiarse en el valor medio. |
+| No determinismo entre corridas | `temperature: 0.0` en los tres YAML. Cualquier diferencia entre re-ejecuciones será atribuible a cambios externos al panel. |
+
+El sesgo de longitud (la posibilidad de que los jueces sub-puntúen respuestas breves pero relevantes) no queda mitigado por el prompt V3, pues este no incluye una instrucción explícita en ese sentido. Se documenta y se vigila en la Sección 9 y en el pilot posterior.
+
+---
+
+## 8. Relación con G-Eval
+
+| Aspecto | G-Eval (HU-04) | Sistema de votación (HU-06 y siguientes) |
+|---|---|---|
+| Modelo o modelos | gpt-4o | gpt-4o, gemini-2.5-flash, claude-haiku-4-5 |
+| Número de jueces | 1 | 3 |
+| Agregación | Form-filling sobre probabilidades en DeepEval (`GEval`) | Esquema de votación de la HU-05 (media + mediana de robustez) |
+| Prompt | V3 con anclas y CoT | V3 con anclas y CoT, idéntico al de G-Eval |
+| Costo aproximado por 900 pares | aproximadamente 5 USD | aproximadamente 7.61 USD |
+
+La fila clave es la del prompt: al ser el mismo en ambos sistemas, las únicas variables que cambian entre G-Eval y el sistema de votación son la mecánica de scoring (form-filling con logprobs frente a prompting directo con parser) y el número de jueces con su agregación.
+
+---
+
+## 9. Limitaciones conocidas
+
+- El modelo `gpt-4o` aparece tanto en el baseline G-Eval como en el panel. Si el modelo tiene un sesgo sistemático en la evaluación de relevancia, este sesgo se replica en parte en el panel. La mitigación parcial proviene de la diferencia de mecánica de scoring entre ambos sistemas.
+- El modelo `claude-haiku-4-5` pertenece a la familia eficiente de Anthropic y es, por diseño, un modelo más pequeño que `gpt-4o` y `gemini-2.5-flash`. Existe la posibilidad de una asimetría de calidad de evaluación dentro del panel, que se vigilará en el pilot.
+- Los tres modelos son propietarios. Una réplica del experimento con alternativas open-source mejoraría la reproducibilidad y se propone como trabajo futuro.
+- Los tres modelos han sido entrenados con esquemas de aprendizaje por refuerzo a partir de retroalimentación humana (RLHF). Pueden compartir sesgos de evaluación heredados del entrenamiento, no presentes en los anotadores humanos del dataset.
+- Sesgo de longitud no mitigado por el prompt: el V3 no contiene una instrucción explícita que indique al juez no penalizar respuestas cortas si estas son relevantes. En el pilot del panel se vigilará si los tres jueces sub-puntúan respuestas breves; si se detecta el patrón, se propondrá una corrección puntual del prompt o una extensión del análisis para reportar la sensibilidad de los resultados a la longitud de la respuesta.
+- Diversidad de estilo de prompt sacrificada por control científico: en otras configuraciones (Verga et al., 2024) los jueces de un panel usan prompts deliberadamente distintos para introducir diversidad de razonamiento. Esta tesis descarta esa diversidad para asegurar el aislamiento experimental con G-Eval. Es una decisión consciente y se asume como limitación.
+
+---
+
+## 10. Estimación de costos
+
+Los costos se estiman a partir de las tarifas públicas de cada proveedor a la fecha de redacción y el conteo de tokens del baseline G-Eval (entrada: 1.090.187 tokens; salida: 81.977 tokens para 900 pares). Los valores son orientativos.
+
+| Agente | Modelo | Input USD por millón | Output USD por millón | Costo estimado 900 pares |
+|---|---|---|---|---|
+| judge_openai | gpt-4o | 2.50 | 10.00 | aproximadamente 4.50 USD |
+| judge_google | gemini-2.5-flash | 0.30 | 2.50 | aproximadamente 0.89 USD |
+| judge_anthropic | claude-haiku-4-5 | 1.00 | 5.00 | aproximadamente 2.22 USD |
+| Total panel | | | | aproximadamente 7.61 USD |
+| G-Eval (ya ejecutado) | gpt-4o | | | aproximadamente 5.00 USD |
+| Total estimado de la tesis | | | | entre 12 y 13 USD |
+
+El runner posterior reportará los costos reales por agente al final de la ejecución, tal como hace `scripts/run_geval.py` para el baseline.
+
+---
+
+## 11. Referencias
+
+Anthropic. (2025, octubre). *Claude Haiku 4.5.* Anthropic News. https://www.anthropic.com/news/claude-haiku-4-5
+
+Google DeepMind. (2025). *Gemini 2.5 Flash.* Google DeepMind Models. https://deepmind.google/models/gemini/flash/
+
+Liu, Y., Iter, D., Xu, Y., Wang, S., Xu, R., & Zhu, C. (2023). G-Eval: NLG evaluation using GPT-4 with better human alignment. *Proceedings of EMNLP 2023*, 2511–2522. https://aclanthology.org/2023.emnlp-main.153/
+
+OpenAI. (2024). *GPT-4o system card.* OpenAI. https://openai.com/index/gpt-4o-system-card/
+
+Verga, P., Hofstatter, S., Althammer, S., Su, Y., Piktus, A., Arkhangorodsky, A., Xu, M., White, N., & Lewis, P. (2024). Replacing judges with juries: Evaluating LLM generations with a panel of diverse models. *arXiv preprint*. https://arxiv.org/abs/2404.18796
+
+---


### PR DESCRIPTION
# feat(panel): diseño del panel de agentes juez del sistema de votación (HU-06)

## ✨ Context

Segunda historia del bloque del sistema de votación agéntico. La HU-05 (ya en `main`) fijó el operador de agregación (media con mediana de robustez). Esta HU-06 define **quién** agrega: el panel de tres jueces de IA que producirá las puntuaciones individuales para el agregador. La entrega es **enteramente declarativa** (YAML + documento de diseño): no se llaman APIs, no se ejecuta ninguna evaluación. El runner del panel y el módulo `aggregator.py` son historias posteriores.

## 🧠 Rationale behind the change

Tres decisiones de diseño sostienen este PR:

1. **Panel fijo de tres jueces, un proveedor por agente**: `gpt-4o` (OpenAI), `gemini-2.5-flash` (Google) y `claude-haiku-4-5` (Anthropic). Cubre el requisito de al menos dos proveedores distintos del Definition of Done con margen, y el número impar deja la mediana siempre definida sin reglas de desempate (criterio de robustez de la HU-05).
2. **`gpt-4o` aparece tanto en G-Eval como en el panel** de forma deliberada. Comparte modelo entre los dos sistemas para que la comparación final aísle el efecto del *método de evaluación* del efecto del *modelo*.
3. **Prompt único V3 compartido por los tres agentes**, en lugar de prompts estilísticamente distintos por juez. Decisión consciente: se sustituye el requisito de diversidad de prompt por el de **control científico estricto**. Con prompt y modelo (en el caso de `judge_openai`) constantes respecto a G-Eval, la diferencia `judge_openai` frente a G-Eval queda atribuible solo a la mecánica de scoring (form-filling con logprobs en DeepEval frente a prompting directo con parser), y la diferencia panel agregado frente a G-Eval queda atribuible a esa mecánica más la agregación. El precio metodológico es la pérdida de un eje de mitigación de sesgo; queda documentado como limitación.

Adicional: `temperature: 0.0` en los tres jueces, no negociable, para que el juicio sea determinista dado el mismo input.

## Type of changes

- [x] 📝 Documentation
- [x] 👷 🔧 CI or Configuration Files
- [x] Other: entregable de diseño de la tesis (declarativo, sin código ejecutable)

## 🛠 What does this PR implement

- **`configs/agents/agent_openai.yaml`** — `judge_openai`, `model: "gpt-4o"`, `provider: "openai"`, `api_key_env: "OPENAI_API_KEY"`, `temperature: 0.0`, `prompt_file: "configs/prompts/geval_relevance_prompt.txt"` (V3), `score_range {min: 1, max: 5}`, `independence: true`, `methodology_note` que registra el aislamiento metodológico, y bloque de comentarios `INDEPENDENCE GUARANTEE` al inicio.
- **`configs/agents/agent_google.yaml`** — análogo con `gemini-2.5-flash` y `GOOGLE_API_KEY`. `methodology_note` sobre diversidad de proveedor con prompt constante.
- **`configs/agents/agent_anthropic.yaml`** — análogo con `claude-haiku-4-5` (lanzamiento de octubre de 2025) y `ANTHROPIC_API_KEY`. `methodology_note` indica que **no** se usa extended thinking, para conservar la comparabilidad entre jueces.
- **`docs/agent_panel_design.md`** — documento académico en español (163 líneas) con once secciones, en el estilo de `docs/voting_scheme_analysis.md` (H1 en inglés, cuerpo en español, sin emojis ni caracteres tipo IA, tablas con texto, referencias APA con URL consultable). Cubre: contexto de la tesis, fundamentación metodológica (incluye la decisión de prompt único), arquitectura con diagrama ASCII, descripción por agente, garantía de diversidad (restringida a proveedor y modelo, con nota explícita del trade-off), mecanismo de independencia, mitigación de sesgos (tres riesgos cubiertos, uno transferido a limitaciones), relación con G-Eval, limitaciones conocidas (sesgo de longitud no mitigado por el prompt, asimetría potencial por `claude-haiku-4-5` como modelo eficiente, modelos propietarios), estimación de costos (aproximadamente 7.61 USD para 900 pares) y referencias.
- **`CHANGELOG.md`** — nueva entrada para HU-06 bajo `## [Unreleased]` → `### Added`, encima de la entrada de HU-05 ya migrada a `[0.4.0]` por mí en una PR previa.

## 🙈 Missing

Quedan para historias posteriores:

- **Runner del panel**: script que invoque los tres agentes en paralelo o secuencial, parsee el score y persista resultados (próxima HU). El YAML no incluye `thinking_budget` para Gemini ni `extended_thinking` para Claude porque el spec exige estructura exacta; el runner tendrá que desactivarlos.
- **Módulo `src/voting/aggregator.py`** definido en HU-05; pendiente de implementar.
- **Pilot del panel** sobre las 20 conversaciones del pilot de G-Eval (HU posterior), donde se vigilará explícitamente el sesgo de longitud anotado como limitación.
- **Aprobación del director** en el issue de HU-06 (paso del DoD).

## 🧪 How should this be tested?

Es un entregable declarativo; la verificación es estructural, no de ejecución. Sin llamadas a APIs.

```bash
# 1. YAML parseable
for f in configs/agents/agent_*.yaml; do
  uv run python -c "import yaml; yaml.safe_load(open('$f'))"
done

# 2. Modelos exactos del spec
grep -hE '^model:' configs/agents/*.yaml
# esperado:
#   model: "gpt-4o"
#   model: "gemini-2.5-flash"
#   model: "claude-haiku-4-5"

# 3. temperature: 0.0 una vez por archivo
grep -c '^temperature: 0.0$' configs/agents/*.yaml

# 4. Prompt único compartido (V3)
grep -h '^prompt_file:' configs/agents/*.yaml | sort -u
# esperado: prompt_file: "configs/prompts/geval_relevance_prompt.txt"

# 5. V3 sin modificar
git diff configs/prompts/geval_relevance_prompt.txt   # debe estar vacío

# 6. Hooks del repo
uv run pre-commit run --files \
  configs/agents/agent_openai.yaml \
  configs/agents/agent_google.yaml \
  configs/agents/agent_anthropic.yaml \
  docs/agent_panel_design.md \
  CHANGELOG.md
```

Verificación documental: revisar `docs/agent_panel_design.md` y confirmar que la Sección 5 documenta el trade-off de la decisión de prompt único, y que la Sección 9 lista el sesgo de longitud como limitación a vigilar en el pilot.
