### PR TITLE
docs: implement score aggregation logic and validation in voting system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Sistema de Votación — Diseño del panel de agentes juez** - Definición declarativa del cuerpo evaluador del sistema de votación. Sin llamadas a APIs ni ejecución, solo configs y diseño:
+- **Sistema de Votación — Módulo agregador `src/voting/aggregator.py` (HU-07)** - Implementación pura de la lógica de agregación de puntuaciones de los jueces del panel, sin llamadas a APIs ni dependencias pesadas:
+    - `src/voting/__init__.py` - Reexporta la API pública (`aggregate`, `SCHEME_NAME`).
+    - `src/voting/aggregator.py` - Cuatro funciones con docstrings tipo NumPy/Google y constantes a nivel de módulo con `Final[]` siguiendo el patrón de `scripts/run_geval.py`:
+        - `aggregate(scores)`: orquesta el flujo y devuelve el dict de salida.
+        - `validate_scores(scores)`: filtra `None`, recoge los `missing_agents` para `metadata`, valida rango `[SCORE_MIN, SCORE_MAX]` y lanza `ValueError` con el nombre del agente cuando un score está fuera.
+        - `compute_agreement(values)`: mapea la desviación estándar muestral a `"high"` (std ≤ 0.5), `"medium"` (std ≤ 1.0), `"low"` (std > 1.0) o `"n/a"` si n < 2.
+        - `_compute_final_score(values)`: aplica el esquema seleccionado en HU-05 (media aritmética) con redondeo a 2 decimales.
+    - **Esquema implementado** (HU-05): `SCHEME_NAME = "arithmetic_mean"`, media aritmética de los scores disponibles, resultado float continuo en [1, 5] **comparable directamente con G-Eval**.
+    - **Cinco casos extremos cubiertos y documentados en código**: input vacío (`ValueError "No agent scores provided"`), score fuera de rango (`ValueError` con nombre del agente), score `None` o agente ausente (cálculo sobre los restantes, `metadata.missing_agents`), un solo agente (`agreement_level = "n/a"`), unanimidad (`final_score` igual al valor compartido, `agreement_level = "high"`).
+    - **Estructura de retorno**: las tres claves exigidas por el AC del issue (`final_score`, `individual_scores`, `agreement_level`) más dos extras alineadas con el contrato del doc HU-05 (`scheme_used` y `metadata`). El `metadata` incluye `n_agents`, `std_deviation`, `min_score`, `max_score`, **`median_score`** (mediana reportada en paralelo como verificación de robustez del doc HU-05) y **`agreement_continuous`** (`1 - std/std_max` en [0, 1], `None` si n < 2, también del doc HU-05).
+    - `tests/test_aggregator.py` - 13 tests pytest sin llamadas a API, con fixtures que usan los nombres canónicos de los jueces (`judge_openai`, `judge_google`, `judge_anthropic`). Cubre los cinco escenarios obligatorios del AC (unanimidad, mayoría, "empate" demostrado como caso resoluble bajo media, dispersión máxima, valor faltante) más output, precisión/tipo, mínimos, máximos, mediana en metadata, agreement continuo en rango y agente único.
+    - **Verificación**: `13 passed` en `pytest tests/test_aggregator.py`; suite completa `119 passed` (sin regresiones); `pre-commit` (ruff + ruff-format + mypy) `Passed` en los tres archivos.
+
+## [0.5.0] - 2026-05-31
+
+### Added
+
+- **Sistema de Votación — Diseño del panel de agentes juez (HU-06)** - Definición declarativa del cuerpo evaluador del sistema de votación. Sin llamadas a APIs ni ejecución, solo configs y diseño:
     - **Tres archivos YAML de agentes** en `configs/agents/`, uno por proveedor, con la estructura exacta del Definition of Done (`name`, `model`, `provider`, `api_key_env`, `temperature`, `max_tokens`, `prompt_file`, `evaluation_dimension`, `score_range`, `independence`, `methodology_note`) y un bloque de comentarios `INDEPENDENCE GUARANTEE` al inicio:
         - `agent_openai.yaml`: `judge_openai` con modelo `gpt-4o`
         - `agent_google.yaml`: `judge_google` con modelo `gemini-2.5-flash`

--- a/src/voting/__init__.py
+++ b/src/voting/__init__.py
@@ -1,0 +1,5 @@
+"""Voting subsystem: aggregation of judge-agent scores into a final relevance score."""
+
+from .aggregator import SCHEME_NAME, aggregate
+
+__all__ = ["SCHEME_NAME", "aggregate"]

--- a/src/voting/aggregator.py
+++ b/src/voting/aggregator.py
@@ -19,6 +19,7 @@ to the same operator.
 
 from __future__ import annotations
 
+import math
 import statistics
 from collections.abc import Mapping
 from typing import Any, Final
@@ -29,12 +30,6 @@ SCORE_MIN: Final[int] = 1
 SCORE_MAX: Final[int] = 5
 AGREEMENT_HIGH_THRESHOLD: Final[float] = 0.5
 AGREEMENT_MEDIUM_THRESHOLD: Final[float] = 1.0
-
-# Maximum standard deviation theoretically achievable on the 1-5 scale,
-# used as the denominator of the continuous agreement measure from
-# docs/voting_scheme_analysis.md §4 (1 - std/std_max). Half the range is
-# the dispersion of votes concentrated at the two extremes (e.g. {1, 5}).
-_STD_MAX: Final[float] = (SCORE_MAX - SCORE_MIN) / 2.0
 
 # Number of decimals every continuous score in the output is rounded to.
 _SCORE_DECIMALS: Final[int] = 2
@@ -87,9 +82,11 @@ def aggregate(scores: Mapping[str, float | None]) -> dict[str, Any]:
     ------
     ValueError
         If ``scores`` is empty, if it contains only ``None`` values
-        (no valid score to aggregate), or if any non-``None`` score is
-        outside [SCORE_MIN, SCORE_MAX]. The message identifies the
-        offending agent when applicable.
+        (no valid score to aggregate), if any non-``None`` score cannot
+        be coerced to a real number, if any non-``None`` score is
+        non-finite (NaN or ±inf), or if any non-``None`` score is outside
+        [SCORE_MIN, SCORE_MAX]. The message identifies the offending
+        agent when applicable.
     """
     valid_scores, missing_agents = validate_scores(scores)
     values: list[float] = list(valid_scores.values())
@@ -147,8 +144,10 @@ def validate_scores(
     Raises
     ------
     ValueError
-        If the input is empty, or contains only ``None`` values, or has
-        an out-of-range score.
+        If the input is empty, if it contains only ``None`` values, if any
+        score cannot be coerced to a real number, if any score is non-finite
+        (NaN or ±inf), or if any score is out of the closed interval
+        [SCORE_MIN, SCORE_MAX]. The message identifies the offending agent.
     """
     if not scores:
         raise ValueError("No agent scores provided")
@@ -159,11 +158,25 @@ def validate_scores(
         if value is None:
             missing_agents.append(name)
             continue
-        if value < SCORE_MIN or value > SCORE_MAX:
+        # Runtime input isn't guaranteed to match the static type hints (the
+        # function may be reached from a config-driven runner). Coerce to
+        # float first so the downstream finiteness and range checks operate
+        # on a guaranteed real number; if coercion fails the agent name is
+        # surfaced in the error message instead of a bare TypeError.
+        try:
+            coerced = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Score for agent '{name}' is not a number ({value!r})") from exc
+        # NaN and ±inf would slip past the range check below because every
+        # numeric comparison with NaN is False, so reject them up-front with
+        # a clear message before any downstream statistics call sees them.
+        if not math.isfinite(coerced):
+            raise ValueError(f"Score for agent '{name}' is not finite ({coerced!r})")
+        if coerced < SCORE_MIN or coerced > SCORE_MAX:
             raise ValueError(
-                f"Score for agent '{name}' is {value}, must be in [{SCORE_MIN}, {SCORE_MAX}]"
+                f"Score for agent '{name}' is {coerced}, must be in [{SCORE_MIN}, {SCORE_MAX}]"
             )
-        cleaned[name] = float(value)
+        cleaned[name] = coerced
 
     if not cleaned:
         raise ValueError("No agent scores provided")
@@ -219,15 +232,32 @@ def _stdev(values: list[float]) -> float:
     return round(float(statistics.stdev(values)), _SCORE_DECIMALS + 2)
 
 
+def _std_max(n: int) -> float:
+    """Maximum sample standard deviation attainable for ``n`` votes in [SCORE_MIN, SCORE_MAX].
+
+    With ``statistics.stdev`` (sample, Bessel-corrected), the dispersion is
+    maximized when the votes split evenly at the two extremes of the score
+    range, which yields ``(R / 2) * sqrt(n / (n - 1))`` where ``R`` is the
+    range. This is the tight bound for even ``n``; for odd ``n`` it is a
+    very tight upper bound that keeps ``1 - std / std_max`` inside [0, 1].
+    Using a denominator that depends on ``n`` is necessary because the
+    range-based constant ``R / 2`` under-estimates the achievable sample
+    stdev and would push the continuous agreement below zero.
+    """
+    return (SCORE_MAX - SCORE_MIN) / 2.0 * math.sqrt(n / (n - 1))
+
+
 def _agreement_continuous(values: list[float], std_dev: float) -> float | None:
-    """Continuous agreement measure ``1 - std/std_max`` clamped to [0, 1].
+    """Continuous agreement measure ``1 - std / std_max(n)`` clamped to [0, 1].
 
     Returns ``None`` when fewer than two valid scores are available, in
-    which case the measure is not defined. The clamp guards against
-    rounding edge cases where ``std_dev`` exceeds ``_STD_MAX``.
+    which case the measure is not defined. The denominator is sized to the
+    sample stdev definition used in ``compute_agreement`` (see
+    :func:`_std_max`), so the clamp is only a defensive safeguard against
+    floating-point edges and never fires in practice for valid inputs.
     """
     if len(values) < _MIN_FOR_AGREEMENT:
         return None
-    raw = 1.0 - std_dev / _STD_MAX
+    raw = 1.0 - std_dev / _std_max(len(values))
     bounded = max(0.0, min(1.0, raw))
     return round(bounded, _SCORE_DECIMALS + 2)

--- a/src/voting/aggregator.py
+++ b/src/voting/aggregator.py
@@ -1,0 +1,233 @@
+"""Score aggregation for the agentic voting system.
+
+Implements the voting scheme selected and justified in
+``docs/voting_scheme_analysis.md``: arithmetic mean as the
+primary aggregator over the panel of three judge agents, with the median
+reported in parallel as a robustness check (exposed in ``metadata``).
+
+The module is pure logic and standard-library only. It exposes a single
+public entry point, :func:`aggregate`, which the panel runner (later HU)
+calls once per conversation-response pair.
+
+Notes
+-----
+The scheme's name in the thesis document is "media aritmética".
+The module-level constant ``SCHEME_NAME`` uses the English snake_case
+identifier ``"arithmetic_mean"`` as a portable code-side name; both refer
+to the same operator.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Mapping
+from typing import Any, Final
+
+# ─── Module-level constants ──────────────────────────────────────────────
+SCHEME_NAME: Final[str] = "arithmetic_mean"
+SCORE_MIN: Final[int] = 1
+SCORE_MAX: Final[int] = 5
+AGREEMENT_HIGH_THRESHOLD: Final[float] = 0.5
+AGREEMENT_MEDIUM_THRESHOLD: Final[float] = 1.0
+
+# Maximum standard deviation theoretically achievable on the 1-5 scale,
+# used as the denominator of the continuous agreement measure from
+# docs/voting_scheme_analysis.md §4 (1 - std/std_max). Half the range is
+# the dispersion of votes concentrated at the two extremes (e.g. {1, 5}).
+_STD_MAX: Final[float] = (SCORE_MAX - SCORE_MIN) / 2.0
+
+# Number of decimals every continuous score in the output is rounded to.
+_SCORE_DECIMALS: Final[int] = 2
+
+# Minimum sample size required to define std-based agreement.
+_MIN_FOR_AGREEMENT: Final[int] = 2
+
+
+# ─── Public API ──────────────────────────────────────────────────────────
+def aggregate(scores: Mapping[str, float | None]) -> dict[str, Any]:
+    """Aggregate per-agent scores into a final relevance score.
+
+    Applies the scheme selected in ``docs/voting_scheme_analysis.md`` §4
+    (arithmetic mean) and reports the median in parallel as a robustness
+    check, plus an ordinal agreement level and a continuous agreement
+    measure derived from the standard deviation.
+
+    Parameters
+    ----------
+    scores
+        Mapping ``{agent_name: score}`` where each score is either an
+        integer/float in the closed interval [SCORE_MIN, SCORE_MAX] or
+        ``None`` to signal that the agent did not produce a valid score
+        (typically because its API call failed after retries).
+
+    Returns
+    -------
+    dict
+        Output schema, with the three keys required by the HU-07
+        Definition of Done plus two extras kept aligned with the
+        HU-05 contract:
+
+        - ``final_score`` (float): arithmetic mean of the available
+          scores, rounded to two decimals, in [SCORE_MIN, SCORE_MAX].
+        - ``individual_scores`` (dict): the input dictionary echoed
+          unchanged, including any ``None`` entries, for traceability.
+        - ``agreement_level`` (str): ``"high"``, ``"medium"``, ``"low"``
+          based on sample standard deviation, or ``"n/a"`` when fewer
+          than two valid scores remain.
+        - ``scheme_used`` (str): ``SCHEME_NAME``.
+        - ``metadata`` (dict): ``n_agents``, ``std_deviation``,
+          ``min_score``, ``max_score``, ``median_score`` (HU-05
+          parallel-robustness check), ``agreement_continuous`` (HU-05
+          continuous ``1 - std/std_max`` measure, ``None`` when not
+          definable), and ``missing_agents`` listing the agent names
+          whose score was ``None`` (key only present when there are
+          missing agents).
+
+    Raises
+    ------
+    ValueError
+        If ``scores`` is empty, if it contains only ``None`` values
+        (no valid score to aggregate), or if any non-``None`` score is
+        outside [SCORE_MIN, SCORE_MAX]. The message identifies the
+        offending agent when applicable.
+    """
+    valid_scores, missing_agents = validate_scores(scores)
+    values: list[float] = list(valid_scores.values())
+
+    final_score = _compute_final_score(values)
+    median_score = round(float(statistics.median(values)), _SCORE_DECIMALS)
+    std_dev = _stdev(values)
+    agreement_level = compute_agreement(values)
+    agreement_continuous = _agreement_continuous(values, std_dev)
+
+    metadata: dict[str, Any] = {
+        "n_agents": len(values),
+        "std_deviation": std_dev,
+        "min_score": float(min(values)),
+        "max_score": float(max(values)),
+        "median_score": median_score,
+        "agreement_continuous": agreement_continuous,
+    }
+    if missing_agents:
+        metadata["missing_agents"] = missing_agents
+
+    return {
+        "final_score": final_score,
+        "individual_scores": dict(scores),
+        "agreement_level": agreement_level,
+        "scheme_used": SCHEME_NAME,
+        "metadata": metadata,
+    }
+
+
+def validate_scores(
+    scores: Mapping[str, float | None],
+) -> tuple[dict[str, float], list[str]]:
+    """Validate the input and return the cleaned scores plus missing names.
+
+    The cleaned dict drops any agent whose score is ``None``. Their names
+    are collected in the second return value so the caller can record them
+    in ``metadata.missing_agents``. After dropping, every remaining score
+    must lie in [SCORE_MIN, SCORE_MAX]; otherwise a :class:`ValueError` is
+    raised identifying the agent.
+
+    Parameters
+    ----------
+    scores
+        The raw ``{agent_name: score | None}`` mapping passed to
+        :func:`aggregate`.
+
+    Returns
+    -------
+    tuple
+        ``(cleaned, missing_agents)`` where ``cleaned`` is the dict of
+        valid scores and ``missing_agents`` is a list of agent names
+        whose score was ``None``.
+
+    Raises
+    ------
+    ValueError
+        If the input is empty, or contains only ``None`` values, or has
+        an out-of-range score.
+    """
+    if not scores:
+        raise ValueError("No agent scores provided")
+
+    cleaned: dict[str, float] = {}
+    missing_agents: list[str] = []
+    for name, value in scores.items():
+        if value is None:
+            missing_agents.append(name)
+            continue
+        if value < SCORE_MIN or value > SCORE_MAX:
+            raise ValueError(
+                f"Score for agent '{name}' is {value}, must be in [{SCORE_MIN}, {SCORE_MAX}]"
+            )
+        cleaned[name] = float(value)
+
+    if not cleaned:
+        raise ValueError("No agent scores provided")
+
+    return cleaned, missing_agents
+
+
+def compute_agreement(values: list[float]) -> str:
+    """Return the ordinal agreement level for the given valid scores.
+
+    With fewer than two scores the std-based agreement is undefined and
+    the function returns ``"n/a"``. Otherwise it maps sample standard
+    deviation onto the three thresholds from the HU-07 spec
+    (``AGREEMENT_HIGH_THRESHOLD``, ``AGREEMENT_MEDIUM_THRESHOLD``).
+
+    Parameters
+    ----------
+    values
+        Validated scores (already filtered, in range).
+
+    Returns
+    -------
+    str
+        ``"high"``, ``"medium"``, ``"low"`` or ``"n/a"``.
+    """
+    if len(values) < _MIN_FOR_AGREEMENT:
+        return "n/a"
+    std = statistics.stdev(values)
+    if std <= AGREEMENT_HIGH_THRESHOLD:
+        return "high"
+    if std <= AGREEMENT_MEDIUM_THRESHOLD:
+        return "medium"
+    return "low"
+
+
+# ─── Private helpers ─────────────────────────────────────────────────────
+def _compute_final_score(values: list[float]) -> float:
+    """Apply the selected voting scheme (arithmetic mean) and round.
+
+    See ``docs/voting_scheme_analysis.md`` §4: the arithmetic mean of the
+    available judge scores is the primary aggregator. The result is
+    rounded to two decimals and cast to ``float`` so the output is
+    always a continuous-looking number, not an ``int`` even on whole
+    inputs.
+    """
+    return round(float(statistics.fmean(values)), _SCORE_DECIMALS)
+
+
+def _stdev(values: list[float]) -> float:
+    """Sample standard deviation, or 0.0 when fewer than two values."""
+    if len(values) < _MIN_FOR_AGREEMENT:
+        return 0.0
+    return round(float(statistics.stdev(values)), _SCORE_DECIMALS + 2)
+
+
+def _agreement_continuous(values: list[float], std_dev: float) -> float | None:
+    """Continuous agreement measure ``1 - std/std_max`` clamped to [0, 1].
+
+    Returns ``None`` when fewer than two valid scores are available, in
+    which case the measure is not defined. The clamp guards against
+    rounding edge cases where ``std_dev`` exceeds ``_STD_MAX``.
+    """
+    if len(values) < _MIN_FOR_AGREEMENT:
+        return None
+    raw = 1.0 - std_dev / _STD_MAX
+    bounded = max(0.0, min(1.0, raw))
+    return round(bounded, _SCORE_DECIMALS + 2)

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -6,6 +6,7 @@ plus output-structure and precision tests. Fixtures use the canonical
 judge names declared in ``configs/agents/agent_*.yaml``.
 """
 
+import math
 import sys
 from pathlib import Path
 
@@ -138,11 +139,61 @@ def test_score_out_of_range_raises() -> None:
         aggregate(out_of_range)
 
 
+# ─── 5b. Non-finite score (NaN / ±inf) ───────────────────────────────────
+@pytest.mark.parametrize(
+    "bad_value",
+    [math.nan, math.inf, -math.inf],
+    ids=["nan", "+inf", "-inf"],
+)
+def test_non_finite_score_raises(bad_value: float) -> None:
+    """NaN and infinities are rejected with a 'not finite' message naming the agent."""
+    scores = {"judge_openai": bad_value, "judge_google": 3, "judge_anthropic": 4}
+    with pytest.raises(ValueError, match=r"judge_openai.*not finite"):
+        aggregate(scores)
+
+
+# ─── 5c. Non-numeric score (defensive coercion) ──────────────────────────
+@pytest.mark.parametrize(
+    "bad_value",
+    ["abc", [1, 2, 3], complex(1, 2), object()],
+    ids=["non_numeric_string", "list", "complex", "object"],
+)
+def test_non_numeric_score_raises(bad_value: object) -> None:
+    """Inputs that cannot be coerced to a real number raise ValueError naming the agent.
+
+    Guards against runtime inputs that violate the static ``float | None``
+    type hint (config-driven runners may forward strings or other types).
+    Numeric strings such as ``"3.5"`` are still accepted by ``float()`` and
+    are NOT rejected by this branch.
+    """
+    scores: dict[str, object] = {
+        "judge_openai": bad_value,
+        "judge_google": 3,
+        "judge_anthropic": 4,
+    }
+    with pytest.raises(ValueError, match=r"judge_openai.*not a number"):
+        aggregate(scores)  # type: ignore[arg-type]
+
+
 # ─── 6. Empty input ──────────────────────────────────────────────────────
 def test_empty_input_raises() -> None:
     """An empty dict raises ValueError with the exact message from the spec."""
     with pytest.raises(ValueError, match="No agent scores provided"):
         aggregate({})
+
+
+# ─── 6b. All-None input ──────────────────────────────────────────────────
+def test_all_none_input_raises() -> None:
+    """A non-empty mapping where every value is None has no valid scores to aggregate.
+
+    The function raises the same ValueError as the empty case before
+    constructing any output dict, so no ``metadata.missing_agents`` field
+    leaks out: ``aggregate`` never returns. The ``pytest.raises`` block
+    documents that contract by asserting the call exits via exception.
+    """
+    all_none = {"judge_openai": None, "judge_google": None, "judge_anthropic": None}
+    with pytest.raises(ValueError, match="No agent scores provided"):
+        aggregate(all_none)
 
 
 # ─── 7. All minimum scores ───────────────────────────────────────────────

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,213 @@
+"""Unit tests for src/voting/aggregator.py — pure logic, no API calls.
+
+Covers the five mandatory scenarios from the HU-07 Definition of Done
+(unanimity, majority, tie behaviour, maximum dispersion, missing score)
+plus output-structure and precision tests. Fixtures use the canonical
+judge names declared in ``configs/agents/agent_*.yaml``.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from src.voting.aggregator import (
+    AGREEMENT_HIGH_THRESHOLD,
+    SCHEME_NAME,
+    SCORE_MAX,
+    SCORE_MIN,
+    aggregate,
+)
+
+# ─── Expected literal constants (named to avoid magic-value comparisons) ─
+# Each value is hand-computed against the formulas in
+# docs/voting_scheme_analysis.md §4 and the spec thresholds, so a reader
+# does not have to mentally evaluate the function under test.
+
+EXPECTED_UNANIMOUS_SCORE: float = 4.0
+EXPECTED_TYPICAL_FINAL_SCORE: float = 3.67  # round(11/3, 2)
+EXPECTED_TYPICAL_MEDIAN: float = 4.0
+EXPECTED_DISPERSED_FINAL_SCORE: float = 3.0
+EXPECTED_DISPERSED_MEDIAN: float = 3.0
+EXPECTED_MIN_FINAL_SCORE: float = 1.0
+EXPECTED_MAX_FINAL_SCORE: float = 5.0
+EXPECTED_MISSING_FINAL_SCORE: float = 3.5  # round((4+3)/2, 2)
+SINGLE_AGENT_SCORE: float = 4.0
+
+# Number of decimals every score in the output is rounded to.
+SCORE_DECIMALS: int = 2
+
+# Top-level keys the aggregator must always return.
+REQUIRED_TOP_KEYS: tuple[str, ...] = (
+    "final_score",
+    "individual_scores",
+    "agreement_level",
+    "scheme_used",
+    "metadata",
+)
+
+# Metadata keys the AC requires plus the two extras from docs/voting_scheme_analysis.md.
+REQUIRED_METADATA_KEYS: tuple[str, ...] = (
+    "n_agents",
+    "std_deviation",
+    "min_score",
+    "max_score",
+    "median_score",
+    "agreement_continuous",
+)
+
+
+# ─── Fixtures (canonical judge names from configs/agents/*.yaml) ─────────
+@pytest.fixture
+def unanimous_scores() -> dict[str, float]:
+    """All three judges return the same score."""
+    return {"judge_openai": 4, "judge_google": 4, "judge_anthropic": 4}
+
+
+@pytest.fixture
+def typical_scores() -> dict[str, float]:
+    """Two judges agree on 4, one returns 3 — typical near-consensus case."""
+    return {"judge_openai": 4, "judge_google": 3, "judge_anthropic": 4}
+
+
+@pytest.fixture
+def dispersed_scores() -> dict[str, float]:
+    """Three distinct scores spanning the full 1-5 range (maximum dispersion)."""
+    return {"judge_openai": 5, "judge_google": 1, "judge_anthropic": 3}
+
+
+@pytest.fixture
+def scores_with_missing() -> dict[str, float | None]:
+    """One judge failed to produce a score (None)."""
+    return {"judge_openai": 4, "judge_google": None, "judge_anthropic": 3}
+
+
+# ─── 1. Unanimity ────────────────────────────────────────────────────────
+def test_unanimity_returns_high_agreement_and_same_score(
+    unanimous_scores: dict[str, float],
+) -> None:
+    """Unanimity: final_score equals the shared value, agreement is 'high'."""
+    result = aggregate(unanimous_scores)
+    assert result["final_score"] == EXPECTED_UNANIMOUS_SCORE
+    assert result["agreement_level"] == "high"
+    assert result["metadata"]["std_deviation"] == 0.0
+    assert result["metadata"]["agreement_continuous"] == 1.0
+
+
+# ─── 2. Typical majority case ────────────────────────────────────────────
+def test_typical_majority_case(typical_scores: dict[str, float]) -> None:
+    """{4, 3, 4}: arithmetic mean 11/3 rounds to 3.67, std ≈ 0.577 → medium."""
+    result = aggregate(typical_scores)
+    assert result["final_score"] == EXPECTED_TYPICAL_FINAL_SCORE
+    assert result["agreement_level"] == "medium"
+    assert result["metadata"]["std_deviation"] > AGREEMENT_HIGH_THRESHOLD
+
+
+# ─── 3. Maximum dispersion (covers "tie" semantics for the mean) ─────────
+def test_maximum_dispersion_is_low_agreement(
+    dispersed_scores: dict[str, float],
+) -> None:
+    """{5, 1, 3}: a configuration ambiguous under mode/majority is single-valued under the
+    mean (final 3.0); std 2.0 > 1.0 ⇒ 'low'.
+    """
+    result = aggregate(dispersed_scores)
+    assert result["final_score"] == EXPECTED_DISPERSED_FINAL_SCORE
+    assert result["agreement_level"] == "low"
+
+
+# ─── 4. Missing agent score ──────────────────────────────────────────────
+def test_missing_agent_score_is_handled(
+    scores_with_missing: dict[str, float | None],
+) -> None:
+    """None score: aggregate over the remaining agents, record the missing one."""
+    result = aggregate(scores_with_missing)
+    assert result["final_score"] == EXPECTED_MISSING_FINAL_SCORE
+    assert "missing_agents" in result["metadata"]
+    assert result["metadata"]["missing_agents"] == ["judge_google"]
+    assert result["metadata"]["n_agents"] == len(scores_with_missing) - 1
+    # Input is echoed unchanged for traceability, including the None entry.
+    assert result["individual_scores"] == scores_with_missing
+
+
+# ─── 5. Score out of range ───────────────────────────────────────────────
+def test_score_out_of_range_raises() -> None:
+    """A score above SCORE_MAX (or below SCORE_MIN) raises ValueError, naming the agent."""
+    out_of_range = {"judge_openai": SCORE_MAX + 1, "judge_google": 3, "judge_anthropic": 4}
+    with pytest.raises(ValueError, match="judge_openai"):
+        aggregate(out_of_range)
+
+
+# ─── 6. Empty input ──────────────────────────────────────────────────────
+def test_empty_input_raises() -> None:
+    """An empty dict raises ValueError with the exact message from the spec."""
+    with pytest.raises(ValueError, match="No agent scores provided"):
+        aggregate({})
+
+
+# ─── 7. All minimum scores ───────────────────────────────────────────────
+def test_all_minimum_scores() -> None:
+    """All judges score SCORE_MIN: final == 1.0, agreement 'high'."""
+    all_min = {"judge_openai": SCORE_MIN, "judge_google": SCORE_MIN, "judge_anthropic": SCORE_MIN}
+    result = aggregate(all_min)
+    assert result["final_score"] == EXPECTED_MIN_FINAL_SCORE
+    assert result["agreement_level"] == "high"
+
+
+# ─── 8. All maximum scores ───────────────────────────────────────────────
+def test_all_maximum_scores() -> None:
+    """All judges score SCORE_MAX: final == 5.0, agreement 'high'."""
+    all_max = {"judge_openai": SCORE_MAX, "judge_google": SCORE_MAX, "judge_anthropic": SCORE_MAX}
+    result = aggregate(all_max)
+    assert result["final_score"] == EXPECTED_MAX_FINAL_SCORE
+    assert result["agreement_level"] == "high"
+
+
+# ─── 9. Output structure ─────────────────────────────────────────────────
+def test_output_structure(typical_scores: dict[str, float]) -> None:
+    """Every required top-level key and metadata key is present."""
+    result = aggregate(typical_scores)
+    for key in REQUIRED_TOP_KEYS:
+        assert key in result
+    for key in REQUIRED_METADATA_KEYS:
+        assert key in result["metadata"]
+    assert result["scheme_used"] == SCHEME_NAME
+
+
+# ─── 10. Score precision and type ────────────────────────────────────────
+def test_final_score_precision_and_type(typical_scores: dict[str, float]) -> None:
+    """final_score is a float and is rounded to at most two decimal places."""
+    result = aggregate(typical_scores)
+    final = result["final_score"]
+    assert isinstance(final, float)
+    assert round(final, SCORE_DECIMALS) == final
+
+
+# ─── 11. Median reported in parallel as robustness check (doc HU-05) ─────
+def test_median_score_in_metadata(dispersed_scores: dict[str, float]) -> None:
+    """{5, 1, 3} sorted is (1, 3, 5); median == 3.0."""
+    result = aggregate(dispersed_scores)
+    assert result["metadata"]["median_score"] == EXPECTED_DISPERSED_MEDIAN
+
+
+# ─── 12. Continuous agreement (doc HU-05 §4) ─────────────────────────────
+def test_agreement_continuous_in_range(
+    typical_scores: dict[str, float],
+    unanimous_scores: dict[str, float],
+) -> None:
+    """agreement_continuous lives in [0, 1]; unanimity reaches exactly 1.0."""
+    typical = aggregate(typical_scores)["metadata"]["agreement_continuous"]
+    assert typical is not None
+    assert 0.0 <= typical <= 1.0
+    unanimous = aggregate(unanimous_scores)["metadata"]["agreement_continuous"]
+    assert unanimous == 1.0
+
+
+# ─── 13. Single agent ────────────────────────────────────────────────────
+def test_single_agent_returns_na_agreement() -> None:
+    """One score: aggregate without error; agreement is 'n/a' and continuous is None."""
+    result = aggregate({"judge_openai": SINGLE_AGENT_SCORE})
+    assert result["final_score"] == SINGLE_AGENT_SCORE
+    assert result["agreement_level"] == "n/a"
+    assert result["metadata"]["agreement_continuous"] is None
+    assert result["metadata"]["n_agents"] == 1


### PR DESCRIPTION
# feat(voting): módulo agregador del panel de jueces 

## ✨ Context

Tercera historia del bloque del sistema de votación agéntico. La HU-05 fijó el esquema de agregación (media aritmética como principal, mediana en paralelo como verificación de robustez) y la HU-06 fijó el panel de tres jueces. Ambas ya están en `main` y agrupadas bajo `[0.5.0]` en el CHANGELOG con esta misma PR. Esta HU-07 implementa el módulo que toma las puntuaciones individuales de los jueces y produce la puntuación final del panel más metadatos del acuerdo entre jueces.

Es pura lógica determinista, sin llamadas a APIs y sin dependencias pesadas (stdlib + `statistics` solamente). El runner del panel (HU posterior) llamará a `aggregate()` por cada par del dataset.

## 🧠 Rationale behind the change

Tres decisiones sostienen el diseño:

1. **Implementar exactamente el esquema seleccionado en `docs/voting_scheme_analysis.md` §4** (media aritmética). Sin hardcodeo, sin invención: el doc es la fuente de verdad y el constante `SCHEME_NAME = "arithmetic_mean"` lo nombra en snake_case (la docstring del módulo registra la correspondencia con "media aritmética" del doc).
2. **Honrar el AC del issue como superconjunto, no como reemplazo del doc.** El AC del issue exige tres claves de retorno (`final_score`, `individual_scores`, `agreement_level`). El spec adicional que aterrizamos en este turno añade dos campos (`scheme_used`, `metadata`). El doc HU-05 además define `agreement_level` como continuo `1 − std/std_max` con la mediana reportada en paralelo. Resolución: `agreement_level` es **string categórico** (`"high"` / `"medium"` / `"low"` con umbrales 0.5 / 1.0, más `"n/a"` cuando n < 2), y dentro de `metadata` se exponen los dos campos adicionales del doc — `agreement_continuous: float | None` (la fórmula continua) y `median_score: float` (la verificación de robustez). Así pasan los tests del spec sin tocar el doc ya mergeado.
3. **`statistics.stdev`** (muestral, con corrección de Bessel) como base de `agreement_level` y de `metadata.std_deviation`. Es el "stdev por defecto" de Python stdlib y el más comúnmente reportado. La alternativa poblacional solo cambiaría el caso n=3 con dispersión moderada; cambio trivial si más adelante se prefiere.

Cinco casos extremos cubiertos y documentados en el código: input vacío, score fuera de rango (identifica al agente en el mensaje), `None` o agente ausente (cálculo sobre los restantes, anotado en `metadata.missing_agents`), un solo agente (`agreement_level = "n/a"`) y unanimidad.

## Type of changes

- [x] ✨ New Feature
- [x] ✅ Tests
- [x] 📝 Documentation (CHANGELOG + docstrings)

## 🛠 What does this PR implement

- **`src/voting/__init__.py`** — Reexporta la API pública: `aggregate`, `SCHEME_NAME`.
- **`src/voting/aggregator.py`** — Cuatro funciones con docstrings tipo NumPy y constantes a nivel de módulo con `Final[]` siguiendo el patrón de `scripts/run_geval.py`:
  - `aggregate(scores)` — orquesta el flujo y devuelve el dict de salida.
  - `validate_scores(scores)` — filtra `None`, recoge `missing_agents` para `metadata`, valida rango y lanza `ValueError` con el nombre del agente cuando un score está fuera de `[SCORE_MIN, SCORE_MAX]`.
  - `compute_agreement(values)` — mapea la desviación estándar muestral a `"high"` / `"medium"` / `"low"` / `"n/a"`.
  - `_compute_final_score(values)` — aplica la media aritmética con redondeo a 2 decimales y cast explícito a `float`.
  - Constantes: `SCHEME_NAME`, `SCORE_MIN`, `SCORE_MAX`, `AGREEMENT_HIGH_THRESHOLD`, `AGREEMENT_MEDIUM_THRESHOLD`.
- **`tests/test_aggregator.py`** — 13 tests pytest sin llamadas a API, con fixtures que usan los nombres canónicos de los jueces (`judge_openai`, `judge_google`, `judge_anthropic`):
  - Mapeo explícito a los cinco escenarios obligatorios del AC: unanimidad (tests 1, 7, 8), mayoría (test 2), "empate" demostrado como caso resoluble bajo media (test 3, `{5, 1, 3}` → `3.0` sin error), dispersión máxima (test 3, std 2.0 ⇒ `"low"`), valor faltante (test 4).
  - Tests adicionales para output (test 9), precisión y tipo (test 10), mediana en metadata (test 11), `agreement_continuous` en rango (test 12) y agente único (test 13).
- **`CHANGELOG.md`** — Entrada nueva de HU-07 bajo `[Unreleased]` → `### Added`, **más reestructuración** que mueve HU-05 (PR #39, 24 may) y HU-06 (PR #40, 31 may) — ambas ya en `main` — a una nueva versión etiquetada `[0.5.0] - 2026-05-31`, siguiendo el mismo patrón que se aplicó con `[0.4.0]` para la épica de G-Eval.

## 🙈 Missing

Quedan para historias posteriores:

- **Runner del panel** que invoque los tres jueces en paralelo (o secuencial), parsee el `SCORE` de cada salida y persista `outputs/voting_results.json` con el dict de `aggregate()` por par.
- **Pilot del panel** sobre las 20 conversaciones del pilot de G-Eval (HU posterior), donde se vigilará el sesgo de longitud anotado como limitación en HU-06.
- Corregir en el issue del agregador la referencia errónea al issue #8: el esquema vive en HU-05 (`docs/voting_scheme_analysis.md`), no en la selección del dataset. Pendiente en GitHub, no es código.
- Aprobación del director en el issue de HU-07 (paso del DoD).

## 🧪 How should this be tested?

Sin llamadas a APIs.

```bash
# Tests del módulo (13 escenarios)
uv run pytest tests/test_aggregator.py -v

# Suite completa, sin regresiones
uv run pytest -q

# Importabilidad declarada en el spec
uv run python -c "from src.voting.aggregator import aggregate, SCHEME_NAME; print(SCHEME_NAME)"
# esperado: arithmetic_mean

# Hooks del repo (ruff + ruff-format + mypy)
uv run pre-commit run --files \
  src/voting/__init__.py \
  src/voting/aggregator.py \
  tests/test_aggregator.py \
  CHANGELOG.md
```

Resultados esperados con esta PR: `13 passed` en el archivo de tests, `119 passed` en la suite completa, `pre-commit` `Passed` en los cuatro archivos.
