### PR TITLE
# Public-release preparation: README, REPRODUCE, LICENSE, CITATION, docstrings 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,18 @@
-# API Keys for LLM providers
+# API keys for the three LLM providers used by the project.
+# Copy this file to `.env` and fill in real values. `.env` is gitignored.
+#
+# Phase 3 (G-Eval) only needs OPENAI_API_KEY.
+# Phase 4 (voting system) needs all three keys.
+# Phases 1, 2 and 5 do not need any API key.
+
+# OpenAI — used by G-Eval (gpt-4o) and the OpenAI judge of the voting panel.
+# Console: https://platform.openai.com/api-keys
 OPENAI_API_KEY=your-openai-api-key-here
+
+# Google — used by the Gemini judge (gemini-2.5-flash) of the voting panel.
+# Console: https://aistudio.google.com/apikey
+GOOGLE_API_KEY=your-google-api-key-here
+
+# Anthropic — used by the Claude judge (claude-haiku-4-5) of the voting panel.
+# Console: https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,46 @@
+cff-version: 1.2.0
+message: >-
+  If you use this software or the underlying study in your work, please cite
+  both the software (this entry) and the master's thesis it supports
+  (see `preferred-citation`).
+title: >-
+  Agentic Voting vs G-Eval for Relevance Evaluation in Conversational AI
+abstract: >-
+  Reference implementation and result artifacts for a master's thesis that
+  compares the G-Eval framework (single judge, gpt-4o) against a three-judge
+  agentic voting system (gpt-4o, gemini-2.5-flash, claude-haiku-4-5) on
+  900 conversations from the DailyDialog-Zhao corpus. The repository contains
+  the runners, configurations, executable notebooks, and per-pair JSON
+  results that underpin the descriptive, correlation, significance, error
+  and cost analyses of the thesis.
+type: software
+authors:
+  - family-names: Granda
+    given-names: Laura
+    affiliation: Universidad Pontificia Bolivariana
+license: MIT
+repository-code: https://github.com/LauraGranda/agent-voting-evaluation
+keywords:
+  - conversational AI
+  - relevance evaluation
+  - LLM-as-judge
+  - G-Eval
+  - agentic voting
+  - DailyDialog
+  - statistical equivalence
+  - TOST
+version: 0.7.0
+date-released: 2026-06-19
+preferred-citation:
+  type: thesis
+  title: >-
+    Evaluación de Relevancia en Agentes Conversacionales de IA mediante un
+    Sistema de Votación Agéntico en comparación con el Framework G-EVAL
+  authors:
+    - family-names: Granda
+      given-names: Laura
+      affiliation: Universidad Pontificia Bolivariana
+  thesis-type: Master's thesis
+  institution:
+    name: Universidad Pontificia Bolivariana
+  year: 2026

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Laura Granda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,180 +1,231 @@
-# Evaluación de Relevancia en Agentes Conversacionales de IA mediante un Sistema de Votación Agéntico en comparación con el Framework G-EVAL
+# Agentic Voting vs G-Eval for Relevance Evaluation in Conversational AI
+
+> *Evaluación de Relevancia en Agentes Conversacionales de IA mediante un
+> Sistema de Votación Agéntico en comparación con el Framework G-EVAL*
+> — master's thesis, Universidad Pontificia Bolivariana.
 
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/charliermarsh/ruff)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-## Descripción del Proyecto
+## Overview
 
-Este proyecto de investigación para tesis de maestría implementa un sistema de evaluación de relevancia para agentes conversacionales de IA. El enfoque propuesto compara un sistema innovador de votación agéntica con el marco de evaluación G-EVAL.
+This repository contains the code, configuration and result artifacts for
+a master's thesis that compares two automatic LLM-based evaluators of
+response relevance in open-domain conversation: the published **G-Eval**
+framework (single judge — `gpt-4o`) and an **agentic voting system** that
+aggregates three judges from different providers (`gpt-4o` from OpenAI,
+`gemini-2.5-flash` from Google and `claude-haiku-4-5` from Anthropic).
+Both methods score 900 conversations from the DailyDialog–Zhao dataset
+against four MTurk human relevance scores per item.
 
-**Autor**: Laura Granda
+**Research question.** Given that both methods correlate strongly with
+human judgment, does the additional cost of a three-judge panel buy a
+measurable improvement on the dimensions that matter for downstream use
+— ranking, scalar calibration, robustness — or is the single judge
+statistically equivalent at a fraction of the cost?
 
-## 🏗️ Estructura del Proyecto
+**Headline finding** (HU-12 + HU-14). Both methods are statistically
+equivalent in ranking (TOST on Δρ inside ±0.05) and in absolute error
+(Wilcoxon p = 0.194, Cohen's d = 0.097 negligible). The voting panel
+costs **2.30× more** (USD 8.15 vs USD 3.55 for n = 900) and takes
+**4.20× longer** to run, but improves Cohen's weighted κ by +0.118
+(0.643 vs 0.525, from *moderate* to *substantial*) and exact-agreement
+rate by +8.4 pp. The dollar buys descriptive calibration, not
+inferential improvement.
+
+## Repository structure
 
 ```text
 agent-voting-evaluation/
-├── .env.example                    # Template de variables de entorno
-├── .github/                        # Configuración de GitHub Actions y templates
-├── .code_quality/                  # Configuración de herramientas de calidad
-│   ├── mypy.ini                    # Configuración de type checking
-│   └── ruff.toml                   # Configuración de linter y formatter
-├── configs/                        # Archivos de configuración
-│   ├── prompts/                    # Templates de prompts para LLMs
-│   ├── agents/                     # Configuración de agentes
-│   └── experiment_config.yaml      # Configuración de experimentos
-├── data/                           # Datos del proyecto
-│   ├── raw/                        # Datos crudos sin procesar
-│   └── processed/                  # Datos procesados y listos para usar
-├── docs/                           # Documentación del proyecto
-├── models/                         # Modelos entrenados y serializados
-├── notebooks/                      # Notebooks Jupyter para experimentación
-├── outputs/                        # Outputs generados
-│   ├── figures/                    # Figuras y visualizaciones
-│   └── logs/                       # Logs de ejecución
-├── scripts/                        # Scripts ejecutables
-│   └── test_deepeval_setup.py      # Script para verificar setup de DeepEval
-├── src/                            # Código fuente
-│   ├── data/                       # Módulos para procesamiento de datos
-│   ├── inference/                  # Módulos para inferencia
-│   ├── model/                      # Módulos para modelos
-│   └── pipelines/                  # Pipelines de procesamiento
-├── tests/                          # Tests del proyecto
-├── .gitignore                      # Archivo de exclusión de git
-├── .pre-commit-config.yaml         # Configuración de pre-commit hooks
-├── Makefile                        # Comandos útiles
-├── codecov.yml                     # Configuración de cobertura
-├── mkdocs.yml                      # Configuración de documentación
-├── pyproject.toml                  # Configuración de dependencias
-└── README.md                       # Este archivo
+├── README.md                       # This file
+├── REPRODUCE.md                    # Step-by-step reproduction guide
+├── LICENSE                         # MIT license
+├── CITATION.cff                    # Citation metadata (software + thesis)
+├── CHANGELOG.md                    # Per-HU release notes
+├── pyproject.toml                  # Project metadata + dependencies
+├── uv.lock                         # Locked dependency versions
+├── .env.example                    # Template for API keys
+├── .python-version                 # Python 3.12
+├── Makefile                        # Convenience targets (lint, docs)
+├── configs/
+│   ├── agents/                     # One YAML per judge (openai/google/anthropic)
+│   ├── prompts/                    # Pilot prompts v1/v2/v3 + final G-Eval prompt
+│   └── experiment_config.yaml      # Run-level defaults
+├── data/
+│   ├── raw/dailydialog_zhao/       # Original Zhao et al. (2020) dataset
+│   └── processed/                  # DeepEval-format test cases
+├── docs/                           # Methodological documentation (Spanish)
+│   ├── dataset_selection.md
+│   ├── agent_panel_design.md
+│   ├── voting_scheme_analysis.md
+│   ├── significance_tests_justification.md
+│   └── limitations.md
+├── scripts/                        # Executable scripts (CLI entry points)
+│   ├── download_dataset.py
+│   ├── transform_dataset.py
+│   ├── run_geval.py
+│   ├── run_judge.py                # Single-judge runner (used by voting)
+│   ├── run_voting_system.py
+│   ├── analyze_geval.py
+│   ├── build_pilot_notebook.py
+│   └── test_deepeval_setup.py
+├── src/voting/                     # Library code (aggregator)
+│   └── aggregator.py
+├── notebooks/                      # Jupyter notebooks, executed end-to-end
+│   ├── 01_eda.ipynb                # Exploratory data analysis (HU-03)
+│   ├── 02_prompt_pilot.ipynb       # Prompt pilot v1/v2/v3 (HU-05)
+│   ├── 03_voting_pilot.ipynb       # Voting pilot (HU-08)
+│   ├── 04_descriptive_analysis.ipynb       # HU-10: ρ, κ, MAE per stratum
+│   ├── 05_correlation_analysis.ipynb       # HU-11: Fisher Z + bootstrap CIs
+│   ├── 06_significance_tests.ipynb         # HU-12: Wilcoxon, Steiger, TOST
+│   ├── 07_error_analysis.ipynb             # HU-13: top-20 + taxonomy
+│   └── 08_cost_analysis.ipynb              # HU-14: cost vs quality trade-off
+├── outputs/                        # Generated artifacts (committed)
+│   ├── geval_results.json          # Per-pair G-Eval scores + rationale
+│   ├── voting_results.json         # Per-pair voting scores + per-judge breakdown
+│   ├── *_summary.md                # Citable summaries per HU
+│   ├── figures/                    # 21 PNG figures at 150 dpi
+│   ├── logs/                       # Execution logs (with wall time + cost)
+│   └── agent_scores/               # Per-judge JSON dumps
+└── tests/                          # pytest test suite
 ```
 
-## 🚀 Instalación
+## Requirements
 
-### Requisitos Previos
+- **Python ≥ 3.12** (pinned in `.python-version`).
+- **[uv](https://github.com/astral-sh/uv)** as the package manager
+  (handles virtualenv + lockfile automatically).
+- **Three API keys** (only needed for Phases 3 and 4):
+    - `OPENAI_API_KEY` — for G-Eval and the OpenAI judge.
+    - `GOOGLE_API_KEY` — for the Gemini judge.
+    - `ANTHROPIC_API_KEY` — for the Claude judge.
+- ~ USD 12 of API budget and ~ 3.2 hours of wall time for a full
+  reproduction (see [REPRODUCE.md](./REPRODUCE.md) for the breakdown).
 
-- Python >= 3.12
-- [UV](https://github.com/astral-sh/uv) (gestor de dependencias moderno)
-
-### Pasos de Instalación
-
-1. **Clonar el repositorio**:
-
-   ```bash
-   git clone <repository-url>
-   cd agent-voting-evaluation
-   ```
-
-2. **Configurar variables de entorno**:
-
-   ```bash
-   cp .env.example .env
-   # Editar .env y añadir tus claves de API
-   export OPENAI_API_KEY=tu-openai-api-key
-   export ANTHROPIC_API_KEY=tu-anthropic-api-key
-   ```
-
-3. **Instalar dependencias**:
-
-   ```bash
-   uv sync
-   ```
-
-4. **Verificar la instalación**:
-
-   ```bash
-   uv run python scripts/test_deepeval_setup.py
-   ```
-
-## 📋 Dependencias Principales
-
-El proyecto incluye las siguientes dependencias de producción:
-
-- **deepeval** - Framework de evaluación para LLMs
-- **openai** - Cliente de API de OpenAI
-- **anthropic** - Cliente de API de Anthropic
-- **pandas** - Procesamiento de datos
-- **scipy** - Computación científica
-- **matplotlib** - Visualización de datos
-- **seaborn** - Visualización estadística
-- **python-dotenv** - Gestión de variables de entorno
-- **pyyaml** - Procesamiento de archivos YAML
-
-### Dependencias de Desarrollo
-
-- **pytest** - Framework de testing
-- **pre-commit** - Control de calidad automático
-- **mypy** - Type checking
-- **ruff** - Linting y formatting
-- **mkdocs** - Generación de documentación
-
-## 🔧 Configuración de Experimentos
-
-Edita `configs/experiment_config.yaml` para configurar tus experimentos:
-
-```yaml
-model_name: "gpt-4o"           # Modelo LLM a usar
-temperature: 0.0               # Creatividad del modelo (0-1)
-n_executions: 10               # Número de ejecuciones
-seed: 42                       # Seed para reproducibilidad
-```
-
-## 🧪 Desarrollo y Testing
-
-### Ejecutar tests
+## Installation
 
 ```bash
-uv run pytest
+git clone <repository-url>
+cd agent-voting-evaluation
+cp .env.example .env       # then edit .env and fill in the three API keys
+uv sync                    # creates .venv and installs locked dependencies
+uv run python scripts/test_deepeval_setup.py   # sanity check
 ```
 
-### Ejecutar tests con cobertura
+If you only want to **re-run the analysis** without paying for API calls,
+the committed `outputs/geval_results.json` and `outputs/voting_results.json`
+already contain all the raw scores. Skip Phases 3 and 4 — see the
+"analysis-only mode" section of [REPRODUCE.md](./REPRODUCE.md).
+
+## Reproduction in five phases
+
+All commands are run from the repository root with the `uv run` prefix
+so they execute inside the locked environment.
+
+### Phase 1 — Dataset
 
 ```bash
-uv run pytest --cov=src
+uv run python scripts/download_dataset.py
+uv run python scripts/transform_dataset.py
 ```
 
-### Verificar calidad de código
+Downloads the DailyDialog–Zhao corpus (Zhao et al., 2020) and converts
+it to the DeepEval `ConversationalTestCase` format
+(`data/processed/deepeval_test_cases.json`, 900 entries).
+
+### Phase 2 — Exploratory data analysis
 
 ```bash
-make check
+uv run jupyter nbconvert --to notebook --execute notebooks/01_eda.ipynb \
+  --output 01_eda.ipynb --ExecutePreprocessor.timeout=180
 ```
 
-### Formatear código
+Produces `outputs/figures/01..04_*.png` plus the EDA section of the
+descriptive summary.
+
+### Phase 3 — G-Eval evaluation (≈ 37 min, ≈ USD 3.55)
 
 ```bash
-make lint
+uv run python scripts/run_geval.py
 ```
 
-## 📝 Notas de Desarrollo
+Single-judge G-Eval over the full corpus. Outputs:
+`outputs/geval_results.json` (900 entries with `geval_score`, `reason`,
+`cost_usd`, `tokens_used`) and `outputs/geval_summary_stats.md`.
 
-- Todos los scripts deben incluir type hints (static typing)
-- Docstrings en formato Google
-- Pre-commit hooks se ejecutan automáticamente antes de cada commit
-- Covertura mínima requerida: 90%
-
-## 📚 Documentación
-
-Para más información sobre el proyecto, consulta la documentación en `docs/`.
-
-Para servir la documentación localmente:
+### Phase 4 — Voting system (≈ 157 min, ≈ USD 8.15)
 
 ```bash
-make docs
+uv run python scripts/run_voting_system.py
 ```
 
-## ✨ Características Principales
+Three-judge panel over the full corpus. Outputs:
+`outputs/voting_results.json` (with `individual_scores`,
+`final_vote_score`, `cost_by_agent`, `metadata.std_deviation`) and
+`outputs/voting_summary_stats.md`. The runner has automatic retry on
+transient 503 errors from Gemini.
 
-- **Sistema de Votación Agéntica**: Implementación de un novedoso sistema donde múltiples agentes LLM votan sobre la relevancia
-- **Comparación con G-EVAL**: Benchmarking contra el framework G-EVAL existente
-- **DeepEval Integration**: Uso de DeepEval para métricas de evaluación
-- **Reproducibilidad**: Configuración completa para experimentos reproducibles
-- **Código de Calidad**: Type checking, linting y testing automáticos
+### Phase 5 — Analysis notebooks (≈ 5 min total, no API calls)
 
-## 📄 Licencia
+```bash
+for nb in 04_descriptive_analysis 05_correlation_analysis \
+          06_significance_tests 07_error_analysis 08_cost_analysis; do
+  uv run jupyter nbconvert --to notebook --execute \
+    "notebooks/${nb}.ipynb" --output "${nb}.ipynb" \
+    --ExecutePreprocessor.timeout=300
+done
+```
 
-Este proyecto está bajo licencia MIT License.
+Each notebook reads `outputs/*.json` directly and produces
+`outputs/<topic>_summary.md` plus figures `outputs/figures/10..21_*.png`.
 
-## 👤 Autor
+See [REPRODUCE.md](./REPRODUCE.md) for expected outputs, verification
+counts, troubleshooting, and the analysis-only mode that skips the
+expensive Phases 3 and 4.
 
-**Laura Granda** - [@LauraGranda](https://github.com/LauraGranda)
+## Testing and code quality
+
+```bash
+uv run pytest -q              # run the test suite
+uv run pre-commit run --all-files   # ruff + ruff-format + sanity hooks
+make check                    # mypy + ruff + tests
+```
+
+## Documentation
+
+The detailed methodological documents live in [`docs/`](./docs/) (in
+Spanish, matching the thesis language):
+
+- [`docs/dataset_selection.md`](./docs/dataset_selection.md) — corpus
+  rationale (DailyDialog–Zhao).
+- [`docs/agent_panel_design.md`](./docs/agent_panel_design.md) — judge
+  selection and panel architecture.
+- [`docs/voting_scheme_analysis.md`](./docs/voting_scheme_analysis.md) —
+  aggregation scheme (arithmetic mean) and alternatives.
+- [`docs/significance_tests_justification.md`](./docs/significance_tests_justification.md)
+  — Wilcoxon vs t, Steiger overlapping, TOST equivalence.
+- [`docs/limitations.md`](./docs/limitations.md) — dataset, G-Eval,
+  voting, shared limitations, and directions for future work.
+
+A user-facing release history is in [`CHANGELOG.md`](./CHANGELOG.md).
+
+## How to cite
+
+Citation metadata is provided in [`CITATION.cff`](./CITATION.cff) using
+the [Citation File Format](https://citation-file-format.github.io/) v1.2.0.
+GitHub renders a "Cite this repository" widget from that file. The
+preferred citation points at the thesis; a software-style citation is
+also available for code reuse.
+
+## License
+
+This project is released under the [MIT License](./LICENSE).
+
+## Author
+
+**Laura Granda** — Universidad Pontificia Bolivariana.
+Master's thesis on automatic evaluation of conversational AI.
+GitHub: [@LauraGranda](https://github.com/LauraGranda).

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -1,0 +1,307 @@
+# Reproducing the Experiments
+
+This document is the step-by-step recipe for reproducing every result
+in this repository starting from a clean checkout. It assumes no prior
+knowledge of the project; if you are looking for an overview first,
+read [`README.md`](./README.md).
+
+All commands run from the repository root. Every Python command is
+prefixed with `uv run` so it executes inside the locked virtual
+environment created by `uv sync`.
+
+## 1. Tested environment
+
+| Component | Version |
+|---|---|
+| OS | Ubuntu 22.04 (via WSL2 on Windows 11) |
+| Kernel | Linux 6.6.x WSL2 |
+| Python | 3.12 (pinned in `.python-version`) |
+| `uv` | 0.5+ (any recent release works) |
+| Disk | ≈ 3 GB free for `.venv`, dataset, outputs |
+| RAM | 4 GB is enough; notebooks 06/07 use < 1 GB |
+
+The pipeline does not need a GPU. macOS and native Linux should work
+identically; native Windows has not been tested but should work if
+`uv` is installed.
+
+## 2. Bootstrap
+
+```bash
+git clone <repository-url>
+cd agent-voting-evaluation
+uv sync
+```
+
+`uv sync` reads `pyproject.toml` + `uv.lock`, creates `.venv/`, and
+installs the exact pinned versions of every dependency. Re-runs are
+no-ops if nothing changed.
+
+Verify:
+
+```bash
+uv run python --version          # → Python 3.12.x
+uv run python -c "import deepeval, openai, anthropic, google.genai; print('OK')"
+```
+
+## 3. API key configuration
+
+The runners need three keys. Phase 5 (analysis notebooks) does **not**
+need any of them, so if you only want to reproduce the analysis from
+the committed JSON, you can skip this section — see §8.
+
+### 3.1. Get the keys
+
+| Provider | Console | Used by |
+|---|---|---|
+| OpenAI | <https://platform.openai.com/api-keys> | `gpt-4o` for G-Eval (Phase 3) and `judge_openai` (Phase 4) |
+| Google | <https://aistudio.google.com/apikey> | `gemini-2.5-flash` for `judge_google` (Phase 4) |
+| Anthropic | <https://console.anthropic.com/settings/keys> | `claude-haiku-4-5` for `judge_anthropic` (Phase 4) |
+
+Each key only needs the default scope (chat completions / generate
+content). No tool/file/admin scopes are required.
+
+### 3.2. Write the `.env` file
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` and replace the placeholder values:
+
+```dotenv
+OPENAI_API_KEY=sk-...           # from https://platform.openai.com/api-keys
+GOOGLE_API_KEY=AI...            # from https://aistudio.google.com/apikey
+ANTHROPIC_API_KEY=sk-ant-...    # from https://console.anthropic.com/settings/keys
+```
+
+`.env` is git-ignored. Never commit it.
+
+### 3.3. Verify connectivity
+
+```bash
+uv run python scripts/test_deepeval_setup.py
+```
+
+Expected: a single line per provider confirming that the API responds.
+If any provider fails, fix it before continuing — `run_voting_system.py`
+refuses to start if any of the three keys is missing or invalid.
+
+## 4. Phase-by-phase reproduction
+
+### Phase 1 — Dataset (≈ 30 s, no API)
+
+```bash
+uv run python scripts/download_dataset.py
+uv run python scripts/transform_dataset.py
+```
+
+| File | Expected | Size |
+|---|---|---|
+| `data/raw/dailydialog_zhao/ACL2020_data.zip` | the original archive | ≈ 1.6 MB |
+| `data/raw/dailydialog_zhao/dataset.json` | 900 entries with `turns[]`, `response`, `human_relevance_score`, `raw_relevance_scores` | ≈ 776 KB |
+| `data/processed/deepeval_test_cases.json` | 900 entries in DeepEval `ConversationalTestCase` format | ≈ 1 MB |
+
+Verify:
+
+```bash
+uv run python -c "import json; print(len(json.load(open('data/processed/deepeval_test_cases.json'))))"
+# → 900
+```
+
+### Phase 2 — Exploratory data analysis (≈ 1 min, no API)
+
+```bash
+uv run jupyter nbconvert --to notebook --execute notebooks/01_eda.ipynb \
+  --output 01_eda.ipynb --ExecutePreprocessor.timeout=180
+```
+
+| Output | What |
+|---|---|
+| `outputs/figures/01_histogram_relevance.png` | Histogram of human relevance scores |
+| `outputs/figures/02_boxplot_by_model.png` | Boxplot per generator model |
+| `outputs/figures/03_frequency_table.png` | Frequency table heatmap |
+| `outputs/figures/04_interannotator_std.png` | Std among the 4 MTurk annotators |
+
+### Phase 3 — G-Eval evaluation (≈ 37 min, ≈ USD 3.55)
+
+```bash
+uv run python scripts/run_geval.py
+```
+
+The runner checkpoints every 50 entries. Safe to interrupt and resume:
+re-running picks up from the last checkpoint unless `--no-resume` is
+passed.
+
+| Output | What | Size |
+|---|---|---|
+| `outputs/geval_results.json` | 900 entries: `geval_score`, `reason`, `tokens_used`, `cost_usd`, `delta` | ≈ 696 KB |
+| `outputs/geval_summary_stats.md` | Markdown summary (completion %, ρ, distribution, family breakdown) | ≈ 2 KB |
+| `outputs/logs/geval_execution.log` | Structured log with `total wall time:` and `total cost:` on the last lines | ≈ 80 KB |
+
+Verify the final summary line in the log:
+
+```bash
+grep -E "total wall time|total cost" outputs/logs/geval_execution.log | tail -2
+# → total wall time:   2241.1s  (37m 21s)
+# → total cost:        $3.5453
+```
+
+### Phase 4 — Voting system (≈ 157 min, ≈ USD 8.15)
+
+```bash
+uv run python scripts/run_voting_system.py
+```
+
+Three judges run in parallel per item. Tenacity retries on 5xx and
+transient network errors; in the reference run, retries against
+`gemini-2.5-flash` accounted for ~ 35 min of the total wall time
+(157 min real vs ~ 120 min nominal). Re-running resumes from the last
+saved item if interrupted.
+
+| Output | What | Size |
+|---|---|---|
+| `outputs/voting_results.json` | 900 entries: `final_vote_score`, `individual_scores`, `cost_by_agent`, `metadata.std_deviation`, `agreement_level` | ≈ 728 KB |
+| `outputs/voting_summary_stats.md` | Markdown summary (per-judge ρ, family breakdown, agreement levels, cost by agent) | ≈ 3 KB |
+| `outputs/agent_scores/*.json` | One file per judge with its individual responses | ≈ 200 KB each |
+| `outputs/logs/voting_execution.log` | Structured log; final lines have wall time + total cost + per-agent cost | ≈ 250 KB |
+
+Verify:
+
+```bash
+grep -E "total wall time|total cost|judge_(openai|google|anthropic):" \
+  outputs/logs/voting_execution.log | tail -5
+# → total wall time:   9414.0s  (156m 54s)
+# → total cost:        $8.1547
+# →   judge_openai:      $4.3620
+# →   judge_google:      $0.7426
+# →   judge_anthropic:   $3.0501
+```
+
+### Phase 5 — Analysis notebooks (≈ 5 min total, no API)
+
+Run them in numeric order — notebook 06 reads outputs from notebooks
+04 and 05, and notebooks 07–08 reference 06.
+
+```bash
+for nb in 04_descriptive_analysis 05_correlation_analysis \
+          06_significance_tests 07_error_analysis 08_cost_analysis; do
+  uv run jupyter nbconvert --to notebook --execute \
+    "notebooks/${nb}.ipynb" --output "${nb}.ipynb" \
+    --ExecutePreprocessor.timeout=300
+done
+```
+
+Each notebook produces a `outputs/<topic>_summary.md` and one or more
+figures in `outputs/figures/10..21_*.png`. Approximate per-notebook
+times on a modest laptop:
+
+| Notebook | Time | Key outputs |
+|---|---|---|
+| 04 descriptive | ≈ 20 s | `descriptive_analysis_summary.md`, fig 10–13 |
+| 05 correlation | ≈ 90 s (bootstrap n_iter = 10 000) | `correlation_analysis_summary.md`, fig 14 |
+| 06 significance | ≈ 60 s | `significance_tests_summary.md`, fig 15–16 |
+| 07 error | ≈ 30 s | `error_analysis_summary.md`, fig 17–19 |
+| 08 cost | ≈ 10 s | `cost_analysis_summary.md`, fig 20–21 |
+
+## 5. Cost & time budget summary
+
+| Phase | Wall time | API cost | Notes |
+|---|---|---|---|
+| 1 Dataset | ~30 s | $0 | Single HTTP download from Zenodo |
+| 2 EDA | ~1 min | $0 | Local only |
+| 3 G-Eval | ~37 min | **$3.5453** | 900 calls to `gpt-4o`, 1 302 tokens/call |
+| 4 Voting | ~157 min | **$8.1547** | 2 700 calls (3 judges × 900); includes Gemini 503 retries |
+| 5 Analysis | ~5 min | $0 | Reads committed JSON only |
+| **Total** | **~3.2 h** | **~$11.70** | Excluding human review of outputs |
+
+Numbers come from `outputs/cost_analysis_summary.md` (notebook 08),
+which derives them directly from `cost_usd` and `tokens_used` in the
+result files plus the structured wall-time lines in the logs. They are
+spot prices as of run dates (G-Eval: 2026-05-17; voting: 2026-06-07);
+provider tariff changes invalidate these ratios.
+
+## 6. Verification checklist
+
+After a full reproduction, all of the following should hold:
+
+```bash
+# Lengths
+uv run python -c "import json; [print(f, len(json.load(open(f)))) for f in ['outputs/geval_results.json', 'outputs/voting_results.json', 'data/processed/deepeval_test_cases.json']]"
+# → outputs/geval_results.json 900
+# → outputs/voting_results.json 900
+# → data/processed/deepeval_test_cases.json 900
+
+# Cost totals
+uv run python -c "
+import json
+g = json.load(open('outputs/geval_results.json'))
+v = json.load(open('outputs/voting_results.json'))
+print(f'G-Eval total USD: {sum(r[\"cost_usd\"] for r in g):.4f}')
+print(f'Voting total USD: {sum(r[\"cost_usd\"] for r in v):.4f}')
+"
+# → G-Eval total USD: 3.5453
+# → Voting total USD: 8.1547
+
+# Figures
+ls outputs/figures/ | wc -l
+# → 21
+```
+
+## 7. Known issues
+
+- **Gemini 503 transient errors**. `gemini-2.5-flash` returns 503 under
+  load. The voting runner uses `tenacity` with exponential backoff and
+  10 retries; in the reference run, the inflated wall time of ~ 157 min
+  vs the ~ 120 min nominal is entirely explained by these retries. If
+  your run is much longer, the provider may be degraded — try again
+  later or temporarily reduce parallelism in `configs/agents/agent_google.yaml`.
+- **DeepEval cache**. The `.deepeval/` directory is not versioned and
+  may grow large if you re-run G-Eval many times. Delete it freely.
+- **Pre-commit reformatting after notebook edits**. The first
+  `pre-commit run` after editing a notebook tends to reformat it
+  (ruff-format on code cells). Re-run pre-commit a second time and it
+  will pass.
+- **Re-running deletes nothing**. The runners write atomically and
+  resume from checkpoints, but the analysis notebooks **overwrite**
+  the summary markdowns and figures on each execution. Commit them
+  before re-running if you want a diff.
+- **Pricing is spot at run time**. Costs in the logs and in
+  `outputs/cost_analysis_summary.md` are the prices charged on the day
+  of the run, not today. If you re-run, the totals will differ.
+
+## 8. Analysis-only mode (skip Phases 3 and 4)
+
+The committed JSON files in `outputs/` are the actual outputs of the
+reference run, with the per-pair scores, rationales, costs and tokens
+needed by every analysis notebook.
+
+To reproduce the analysis without paying for any API call:
+
+```bash
+# 1. Make sure dataset.json + processed test cases exist
+uv run python scripts/download_dataset.py
+uv run python scripts/transform_dataset.py
+
+# 2. Skip Phases 3 and 4 entirely. Just run the analysis:
+for nb in 04_descriptive_analysis 05_correlation_analysis \
+          06_significance_tests 07_error_analysis 08_cost_analysis; do
+  uv run jupyter nbconvert --to notebook --execute \
+    "notebooks/${nb}.ipynb" --output "${nb}.ipynb" \
+    --ExecutePreprocessor.timeout=300
+done
+```
+
+All five analysis notebooks read from `outputs/geval_results.json`,
+`outputs/voting_results.json`, and `data/raw/dailydialog_zhao/dataset.json`.
+None of them instantiates an LLM client.
+
+Cost: $0. Wall time: ≈ 5 min.
+
+## 9. Tests and quality gates
+
+```bash
+uv run pytest -q              # full test suite
+uv run pre-commit run --all-files   # ruff + ruff-format + sanity hooks
+```
+
+These have no API dependencies and run in seconds.

--- a/scripts/analyze_geval.py
+++ b/scripts/analyze_geval.py
@@ -72,6 +72,7 @@ def model_family(model_name: str) -> str:
 
 # ─── Loading ─────────────────────────────────────────────────────────────
 def load_json(path: Path) -> Any:
+    """Read and parse a JSON file as UTF-8."""
     with open(path, encoding="utf-8") as f:
         return json.load(f)
 
@@ -204,6 +205,7 @@ def krippendorff_alpha_ordinal(ratings: np.ndarray) -> float:
     n = n_c.sum()
 
     def delta2(c: int, k: int) -> float:
+        """Squared interval distance between ordinal categories ``c`` and ``k``."""
         lo, hi = (c, k) if c <= k else (k, c)
         gap = n_c[lo : hi + 1].sum() - (n_c[lo] + n_c[hi]) / 2.0
         return float(gap * gap)
@@ -302,6 +304,7 @@ def ceiling_verdict(geval_rho: float, loo: float) -> str:
 
 # ─── Figures ─────────────────────────────────────────────────────────────
 def fig_scatter(rows: list[dict], path: Path) -> None:
+    """Save the human-vs-G-Eval scatter with best-fit line at ``path``."""
     geval = np.array([r["geval"] for r in rows])
     human = np.array([r["human"] for r in rows])
     fig, ax = plt.subplots(figsize=(6, 6))
@@ -323,6 +326,7 @@ def fig_scatter(rows: list[dict], path: Path) -> None:
 
 
 def fig_residuals(rows: list[dict], path: Path) -> None:
+    """Save the histogram of residuals ``Δ = G-Eval − human`` at ``path``."""
     delta = np.array([r["delta"] for r in rows])
     fig, ax = plt.subplots(figsize=(7, 4.5))
     ax.hist(delta, bins=40, color="#4477aa", edgecolor="white")
@@ -341,6 +345,7 @@ def fig_residuals(rows: list[dict], path: Path) -> None:
 
 
 def fig_delta_boxplot(rows: list[dict], path: Path) -> None:
+    """Save a boxplot of residuals broken down by model family at ``path``."""
     fams = sorted({r["family"] for r in rows})
     data = [[r["delta"] for r in rows if r["family"] == f] for f in fams]
     fig, ax = plt.subplots(figsize=(8, 4.5))
@@ -355,6 +360,7 @@ def fig_delta_boxplot(rows: list[dict], path: Path) -> None:
 
 
 def fig_mean_by_family(family_rows: list[dict], path: Path) -> None:
+    """Save a paired bar plot of human vs G-Eval mean scores per family."""
     names = [g["name"] for g in family_rows]
     human = [g["human_mean"] for g in family_rows]
     geval = [g["geval_mean"] for g in family_rows]
@@ -374,6 +380,7 @@ def fig_mean_by_family(family_rows: list[dict], path: Path) -> None:
 
 
 def fig_ceiling(geval_rho: float, ceiling: dict[str, float], path: Path) -> None:
+    """Save a horizontal bar plot comparing G-Eval against the human agreement ceiling."""
     labels = [
         "Two single humans\n(pairwise)",
         "Human ceiling\n(1 rater vs consensus)",
@@ -408,6 +415,7 @@ def build_report(  # noqa: PLR0913
     n_fail: int,
     fig_dir: Path,
 ) -> str:
+    """Render the full markdown report string from the precomputed pieces."""
     rho = metrics["spearman_rho"]
     bias = metrics["bias"]
     direction = "over-rates" if bias > 0 else "under-rates"
@@ -544,6 +552,7 @@ def build_report(  # noqa: PLR0913
 
 # ─── Orchestration ───────────────────────────────────────────────────────
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the analyse-G-Eval entry point."""
     p = argparse.ArgumentParser(description="Analyse a completed G-Eval run.")
     p.add_argument(
         "--results", type=Path, default=DEFAULT_RESULTS, help="Path to geval_results.json."
@@ -553,6 +562,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main() -> None:
+    """Entry point: load results, compute metrics, render figures and report."""
     args = parse_args()
     results = load_json(args.results)
     dataset = load_json(DATA_PATH)

--- a/scripts/build_pilot_notebook.py
+++ b/scripts/build_pilot_notebook.py
@@ -15,10 +15,12 @@ NB_PATH = Path("notebooks/02_prompt_pilot.ipynb")
 
 
 def md(src: str) -> Any:
+    """Build a markdown notebook cell from a source string."""
     return nbformat.v4.new_markdown_cell(src.rstrip() + "\n")
 
 
 def code(src: str) -> Any:
+    """Build a code notebook cell from a source string."""
     return nbformat.v4.new_code_cell(src.rstrip() + "\n")
 
 
@@ -975,6 +977,7 @@ Regla de decisión:
 
 
 def main() -> None:
+    """Assemble the pilot notebook and write it to disk."""
     nb = nbformat.v4.new_notebook()  # type: ignore[no-untyped-call]
     nb["cells"] = [
         CELL_1,

--- a/scripts/run_geval.py
+++ b/scripts/run_geval.py
@@ -454,6 +454,7 @@ def _model_family(model_name: str) -> str:
 
 
 def _basic_stats(values: Iterable[float]) -> dict[str, float]:
+    """Compute n/mean/median/std/min/max for a numeric iterable."""
     vals = [float(v) for v in values]
     if not vals:
         return {"n": 0, "mean": 0.0, "median": 0.0, "std": 0.0, "min": 0.0, "max": 0.0}
@@ -546,6 +547,7 @@ def render_summary_markdown(
 
 
 def _render_completion_table(s: dict[str, Any]) -> list[str]:
+    """Render the run-completion markdown sub-table from a summary dict."""
     pct_ok = 100 * s["n_ok"] / max(1, s["n_total"])
     return [
         "## Run completion\n",
@@ -561,6 +563,7 @@ def _render_completion_table(s: dict[str, Any]) -> list[str]:
 
 
 def _render_distribution_table(overall: dict[str, float]) -> list[str]:
+    """Render the G-Eval score-distribution markdown sub-table."""
     lines = [
         "## G-Eval score distribution (1-5)\n",
         "| Stat | Value |",
@@ -573,6 +576,7 @@ def _render_distribution_table(overall: dict[str, float]) -> list[str]:
 
 
 def _render_spearman_table(s: dict[str, Any]) -> list[str]:
+    """Render the Spearman-vs-human markdown sub-table."""
     return [
         "## Spearman correlation vs. human_score\n",
         "| Metric | Value |",
@@ -584,6 +588,7 @@ def _render_spearman_table(s: dict[str, Any]) -> list[str]:
 
 
 def _render_family_table(by_family: dict[str, dict[str, float]]) -> list[str]:
+    """Render the per-model-family breakdown markdown sub-table."""
     lines = [
         "## Breakdown by model family\n",
         "| Family | n | mean | median | std | min | max |",
@@ -600,6 +605,7 @@ def _render_family_table(by_family: dict[str, dict[str, float]]) -> list[str]:
 
 
 def _render_failed_table(failed: list[dict[str, Any]]) -> list[str]:
+    """Render the markdown sub-table listing entries that failed evaluation."""
     lines = [
         "## Failed entries\n",
         "| conversation_id | attempts | error |",
@@ -633,6 +639,7 @@ def generate_summary_stats(
 
 # ─── CLI ─────────────────────────────────────────────────────────────────
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the G-Eval runner."""
     p = argparse.ArgumentParser(description="Run G-Eval over the full DailyDialog-Zhao dataset.")
     p.add_argument("--limit", type=int, default=None, help="Evaluate only the first N entries.")
     p.add_argument(
@@ -653,12 +660,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def load_dataset(path: Path) -> list[dict[str, Any]]:
+    """Load the transformed DeepEval-format dataset from ``path``."""
     with open(path, encoding="utf-8") as f:
         data: list[dict[str, Any]] = json.load(f)
     return data
 
 
 def main() -> None:
+    """Entry point: run G-Eval over the dataset and persist results + summary."""
     args = parse_args()
     output_dir: Path = args.output_dir
     log_path = output_dir / "logs" / "geval_execution.log"

--- a/scripts/run_voting_system.py
+++ b/scripts/run_voting_system.py
@@ -527,6 +527,7 @@ def _log_run_summary(
 
 # ─── Stats ───────────────────────────────────────────────────────────────
 def _model_family(model_name: str) -> str:
+    """Collapse a DailyDialog generator name into a coarse family label."""
     if model_name in ("ground-truth", "negative-sample"):
         return model_name
     for family in ("GPT2", "S2S", "HRED", "VHRED"):
@@ -556,6 +557,7 @@ def _basic_stats(values: Iterable[float]) -> dict[str, int | float]:
 
 
 def _spearman_or_nan(xs: list[float], ys: list[float]) -> tuple[float, float, int]:
+    """Return ``(rho, p, n)`` of Spearman or NaN-filled tuple if sample is too small."""
     if len(xs) < MIN_FOR_SPEARMAN or len(ys) < MIN_FOR_SPEARMAN:
         return float("nan"), float("nan"), len(xs)
     rho, p = spearmanr(xs, ys)
@@ -692,6 +694,7 @@ def render_summary_markdown(summary: dict[str, Any]) -> str:
 
 
 def _render_completion_table(s: dict[str, Any]) -> list[str]:
+    """Render the run-completion markdown sub-table from a summary dict."""
     pct_ok = 100 * s["n_ok"] / max(1, s["n_total"])
     lines = [
         "## Run completion\n",
@@ -711,6 +714,7 @@ def _render_completion_table(s: dict[str, Any]) -> list[str]:
 
 
 def _render_distribution_table(overall: dict[str, int | float]) -> list[str]:
+    """Render the final-vote-score distribution markdown sub-table."""
     lines = [
         "## final_vote_score distribution (1-5)\n",
         "| Stat | Value |",
@@ -723,6 +727,7 @@ def _render_distribution_table(overall: dict[str, int | float]) -> list[str]:
 
 
 def _render_spearman_table(s: dict[str, Any]) -> list[str]:
+    """Render the Spearman-vs-human markdown sub-table (panel + per-judge)."""
     lines = [
         "## Spearman correlation vs. human_score\n",
         "| Source | rho | p-value | n |",
@@ -741,6 +746,7 @@ def _render_spearman_table(s: dict[str, Any]) -> list[str]:
 
 
 def _render_family_table(by_family: dict[str, dict[str, int | float]]) -> list[str]:
+    """Render the per-model-family breakdown markdown sub-table."""
     lines = [
         "## Breakdown by model family\n",
         "| Family | n | mean | median | std | min | max |",
@@ -757,6 +763,7 @@ def _render_family_table(by_family: dict[str, dict[str, int | float]]) -> list[s
 
 
 def _render_agreement_table(counts: dict[str, int]) -> list[str]:
+    """Render the panel agreement-levels markdown sub-table."""
     total = sum(counts.values())
     lines = [
         "## Panel agreement levels\n",
@@ -772,6 +779,7 @@ def _render_agreement_table(counts: dict[str, int]) -> list[str]:
 
 
 def _render_failed_table(failed: list[dict[str, Any]]) -> list[str]:
+    """Render the markdown sub-table listing pairs where aggregation refused."""
     lines = [
         "## Failed pairs (aggregate refused)\n",
         "| conversation_id | error |",
@@ -805,6 +813,7 @@ def generate_summary_stats(
 
 # ─── CLI ─────────────────────────────────────────────────────────────────
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the voting-system runner."""
     p = argparse.ArgumentParser(
         description="Run the agentic voting system over the full DailyDialog-Zhao dataset.",
     )
@@ -841,6 +850,7 @@ def _require_keys(agent_configs: list[dict[str, Any]]) -> None:
 
 
 def main() -> None:
+    """Entry point: run the voting panel over the dataset and persist outputs."""
     args = parse_args()
     output_dir: Path = args.output_dir
     log_path = output_dir / "logs" / "voting_execution.log"


### PR DESCRIPTION
# Public-release preparation: README, REPRODUCE, LICENSE, CITATION, docstrings 

## ✨ Context

Cierra el ciclo del proyecto preparándolo para apertura pública en
GitHub. Hoy el repositorio funciona localmente pero un tercero sin
contexto previo no puede reproducir los experimentos: el `README.md`
estaba en español, describía carpetas que no existen (`models/`),
omitía las HUs 04–14 del bloque de análisis y no documentaba el orden
de ejecución de las 5 fases. Faltaban `LICENSE` y `CITATION.cff`, y
`.env.example` omitía `GOOGLE_API_KEY` (necesaria para `judge_google`
en HU-09). HU-15 entrega un README + REPRODUCE en inglés, licencia
MIT, citación CFF v1.2.0, completa `.env.example` con los tres
proveedores, y audita docstrings en `scripts/` y `src/` sin tocar la
lógica.

## 🧠 Rationale behind the change

El criterio de cierre de la tesis exige reproducibilidad de cabo a
rabo por un tercero. La decisión clave fue separar README (overview
y comandos de alto nivel) de REPRODUCE (recipe con outputs esperados,
costos reales de HU-14, troubleshooting por proveedor y modo
analysis-only para reproducir el análisis sin pagar API). Los números
económicos no se estiman: salen directamente de
`outputs/cost_analysis_summary.md` (HU-14) y de los logs estructurados
de los runners. La licencia es MIT por convención académica de código
abierto. La citación es CFF v1.2.0 con `type: software` y
`preferred-citation: thesis` para que GitHub muestre el widget "Cite
this repository" apuntando a la tesis. Para los docstrings se
priorizó cobertura completa (32 funciones documentadas) sin tocar
ninguna línea de lógica — solo documentación.

## Type of changes

- [x] 📝 Documentation
- [x] 🔥 Improvements (Minor refactoring, code changes or optimizations)

## 🛠 What does this PR implement

### Documentación de cara al público

- **NEW** `README.md` (231 líneas, inglés): título + subtítulo en
  español para coincidir con la tesis, badges (uv, ruff, pre-commit,
  mypy, MIT), pregunta de investigación, hallazgo central de HU-12 y
  HU-14, árbol de carpetas real (verificado contra `find`), requisitos
  (Python 3.12, uv, 3 API keys, USD 12 budget, 3,2 h wall time),
  instalación con `uv sync`, 5 fases de reproducción con comandos
  exactos y tiempos/costos por fase, links a CHANGELOG, docs, LICENSE,
  CITATION.cff.
- **NEW** `REPRODUCE.md` (307 líneas, inglés): entorno probado
  (Ubuntu 22.04 vía WSL2, Python 3.12, uv 0.5+), bootstrap con
  `uv sync`, setup paso a paso de las 3 API keys con URLs de consola
  por proveedor, recipes fase por fase con outputs esperados (nombres
  y tamaños), tabla de cost & time budget tomada directamente de HU-14,
  checklist de verificación con `len()` esperados y totales de costo,
  troubleshooting (Gemini 503, DeepEval cache, pre-commit), modo
  analysis-only para saltar Phases 3 y 4 y reproducir notebooks 04-08
  con USD 0 y ~ 5 min.

### Licenciamiento y citación

- **NEW** `LICENSE`: MIT 2026 Laura Granda, texto canónico.
- **NEW** `CITATION.cff`: schema v1.2.0, validado con `yaml.safe_load`.
  Entry principal `type: software` con `repository-code`, `keywords`,
  `version: 0.7.0`, `date-released: 2026-06-19`. Bloque
  `preferred-citation` `type: thesis` apuntando a Universidad
  Pontificia Bolivariana con el título oficial completo en español.

### Configuración de entorno

- **MOD** `.env.example`: añadido `GOOGLE_API_KEY` con URL de consola
  inline; añadidas URLs y comentarios por proveedor; nota de qué fase
  necesita qué key. Las tres keys quedan documentadas (Phase 3 solo
  necesita OpenAI; Phase 4 necesita las tres; Phases 1/2/5 no
  necesitan ninguna).

### Audit de docstrings (cero cambios de lógica)

Audit programático con `ast` detectó 32 funciones sin docstring en
`scripts/`. Cobertura agregada solo con docstrings (sin tocar la
lógica de ninguna función). Audit final retorna **0 funciones sin
documentar**.

- **MOD** `scripts/analyze_geval.py`: 10 docstrings (`load_json`,
  `delta2` (nested), `fig_scatter`, `fig_residuals`, `fig_delta_boxplot`,
  `fig_mean_by_family`, `fig_ceiling`, `build_report`, `parse_args`,
  `main`).
- **MOD** `scripts/build_pilot_notebook.py`: 3 docstrings (`md`, `code`,
  `main`).
- **MOD** `scripts/run_geval.py`: 9 docstrings (`_basic_stats`, los 5
  `_render_*_table` privados, `parse_args`, `load_dataset`, `main`).
- **MOD** `scripts/run_voting_system.py`: 10 docstrings (`_model_family`,
  `_spearman_or_nan`, los 6 `_render_*_table` privados, `parse_args`,
  `main`).
- `src/` ya tenía todos los docstrings desde HU-09.

## 🙈 Missing

- Publicación del repositorio en GitHub (la tarea pide preparar, no
  publicar).
- DOI Zenodo y campo `doi` / `identifiers` en `CITATION.cff` (queda
  como follow-up cuando el repo esté público y archivado en Zenodo).
- Traducción de los docs en `docs/*.md` al inglés (se mantienen en
  español como idioma de la tesis, según indica el enunciado).
- Smoke test end-to-end de las 5 fases completas (la verificación
  cualitativa se hizo contra los outputs ya generados; no se re-corren
  Phases 3 y 4 por costo y tiempo).
- Modificación de la lógica de los scripts (deliberadamente fuera de
  alcance — esta HU es solo documentación).

## 🧪 How should this be tested?

- `cat README.md REPRODUCE.md LICENSE CITATION.cff .env.example` para
  inspección visual.
- `uv run python -c "import yaml; yaml.safe_load(open('CITATION.cff'))"` parsea sin error.
- `grep -E "OPENAI_API_KEY|GOOGLE_API_KEY|ANTHROPIC_API_KEY" .env.example` muestra 3 keys.
- `uv run python -c "import ast; ..."` audit retorna 0 funciones sin docstring en `scripts/` y `src/`.
- `uv run pre-commit run --files README.md REPRODUCE.md LICENSE CITATION.cff .env.example scripts/analyze_geval.py scripts/build_pilot_notebook.py scripts/run_geval.py scripts/run_voting_system.py` verde.
- `uv run pytest -q` → 127 passed (sin regresiones porque los cambios son solo docstrings).
- Lectura cualitativa: seguir REPRODUCE.md §8 (analysis-only mode) y verificar que las 5 fases de notebooks 04–08 corren con USD 0 y ~ 5 min.
